### PR TITLE
Fixarrays

### DIFF
--- a/SmallForth/CompileHelper.cpp
+++ b/SmallForth/CompileHelper.cpp
@@ -11,6 +11,18 @@ CompileHelper::CompileHelper() {
 	this->pLastWordCreated = nullptr;
 }
 
+CompileHelper::~CompileHelper() {
+	if (this->pWordUnderCreation != nullptr) {
+		this->pWordUnderCreation->DecReference();
+		this->pWordUnderCreation = nullptr;
+	}
+	if (this->pLastWordCreated != nullptr) {
+		this->pLastWordCreated->DecReference();
+		this->pLastWordCreated = nullptr;
+	}
+}
+
+
 bool CompileHelper::CompilePushAndLiteralIntoWordBeingCreated(ExecState* pExecState, int64_t literalValue) {
 	if (!pExecState->pStack->Push(literalValue)) {
 		return pExecState->CreateStackOverflowException();
@@ -332,4 +344,18 @@ bool CompileHelper::ExpandLastWordCompiledBy(ExecState* pExecState, int expandBy
 	}
 	pLastWordCreated->ExpandBy(expandBy);
 	return true;
+}
+
+bool CompileHelper::LastCompiledWordHasBody(WordBodyElement** ppBody) {
+	if (this->pLastWordCreated == nullptr) {
+		return false;
+	}
+	return this->pLastWordCreated->GetPterToBody() == ppBody;
+}
+
+void CompileHelper::ForgetLastCompiledWord() {
+	if (this->pLastWordCreated != nullptr) {
+		this->pLastWordCreated->DecReference();
+		this->pLastWordCreated = nullptr;
+	}
 }

--- a/SmallForth/CompileHelper.h
+++ b/SmallForth/CompileHelper.h
@@ -8,6 +8,7 @@ class CompileHelper
 {
 public:
 	CompileHelper();
+	~CompileHelper();
 
 	// Called by other words directly, to compile a pushbvalue into the word, followed by the literal value. 
 //  Works by pushing literal onto stack and then calling "," (compiles pushiliteral and TOS literal into word)
@@ -45,6 +46,9 @@ public:
 	bool ExecuteLastWordCompiled(ExecState* pExecState); 
 
 	bool ExpandLastWordCompiledBy(ExecState* pExecState, int expandBy);
+
+	bool LastCompiledWordHasBody(WordBodyElement** ppBody);
+	void ForgetLastCompiledWord();
 
 
 private:

--- a/SmallForth/ExecState.cpp
+++ b/SmallForth/ExecState.cpp
@@ -8,6 +8,7 @@ using namespace std;
 #include "InputProcessor.h"
 #include "TypeSystem.h"
 #include "ForthFile.h"
+#include "CompileHelper.h"
 
 ExecState::ExecState() 
 : ExecState(nullptr, nullptr, nullptr, nullptr, nullptr) {
@@ -107,16 +108,10 @@ WordBodyElement** ExecState::GetNextWordFromPreviousNestedBodyAndIncIP() {
 	NestAndSetCFA(currentCFA, currentIp);
 	return ppWBE;
 }
-//
-//WordBodyElement** ExecState::GetNextWordPterFromPreviousNestedBodyAndIncIP() {
-//	int currentIp = ip;
-//	WordBodyElement** currentCFA = pExecBody;
-//	UnnestCFA();
-//	WordBodyElement** ppWBE = this->pExecBody+this->ip;
-//	this->ip++;
-//	NestAndSetCFA(currentCFA, currentIp);
-//	return ppWBE;
-//}
+
+bool ExecState::CurrentBodyIsInLastCompiledWord() {
+	return pCompiler->LastCompiledWordHasBody(this->pExecBody);
+}
 
 // This is used to jump.  As jump is inside it's own body, altering the IP would not have any affect, have to alter the IP of 
 //  the body that nested the jump

--- a/SmallForth/ExecState.cpp
+++ b/SmallForth/ExecState.cpp
@@ -34,8 +34,15 @@ ExecState::ExecState(DataStack* pStack, ForthDict* pDict, InputProcessor* pInput
 	this->stringLiteralPrompt = "\"> ";
 
 	for (int n = 0; n < c_maxStates; ++n) {
-		boolStates[n] = false;
-		intStates[n] = 0;
+		WordBodyElement* pElementBool = new WordBodyElement();
+		pElementBool->wordElement_bool = false;
+		boolStates[n] = pElementBool;
+		pElementBool = nullptr;
+
+		WordBodyElement* pElementInt = new WordBodyElement();
+		pElementInt->wordElement_int = 0;
+		intStates[n] = pElementInt;
+		pElementInt = nullptr;
 	}
 }
 
@@ -91,17 +98,7 @@ WordBodyElement** ExecState::GetWordPterAtOffsetFromCurrentBody(int offset) {
 	return ppWBE;
 }
 
-WordBodyElement* ExecState::GetNextWordFromPreviousNestedBodyAndIncIP() {
-	int currentIp = ip;
-	WordBodyElement** currentCFA = pExecBody;
-	UnnestCFA();
-	WordBodyElement* pWBE = this->pExecBody[this->ip];
-	this->ip++;
-	NestAndSetCFA(currentCFA, currentIp);
-	return pWBE;
-}
-
-WordBodyElement** ExecState::GetNextWordPterFromPreviousNestedBodyAndIncIP() {
+WordBodyElement** ExecState::GetNextWordFromPreviousNestedBodyAndIncIP() {
 	int currentIp = ip;
 	WordBodyElement** currentCFA = pExecBody;
 	UnnestCFA();
@@ -110,6 +107,16 @@ WordBodyElement** ExecState::GetNextWordPterFromPreviousNestedBodyAndIncIP() {
 	NestAndSetCFA(currentCFA, currentIp);
 	return ppWBE;
 }
+//
+//WordBodyElement** ExecState::GetNextWordPterFromPreviousNestedBodyAndIncIP() {
+//	int currentIp = ip;
+//	WordBodyElement** currentCFA = pExecBody;
+//	UnnestCFA();
+//	WordBodyElement** ppWBE = this->pExecBody+this->ip;
+//	this->ip++;
+//	NestAndSetCFA(currentCFA, currentIp);
+//	return ppWBE;
+//}
 
 // This is used to jump.  As jump is inside it's own body, altering the IP would not have any affect, have to alter the IP of 
 //  the body that nested the jump

--- a/SmallForth/ExecState.h
+++ b/SmallForth/ExecState.h
@@ -33,8 +33,8 @@ public:
 	WordBodyElement* GetWordAtOffsetFromCurrentBody(int offset);
 	WordBodyElement** GetWordPterAtOffsetFromCurrentBody(int offset);
 
-	WordBodyElement* GetNextWordFromPreviousNestedBodyAndIncIP();
-	WordBodyElement** GetNextWordPterFromPreviousNestedBodyAndIncIP();
+	WordBodyElement** GetNextWordFromPreviousNestedBodyAndIncIP();
+	//WordBodyElement** GetNextWordPterFromPreviousNestedBodyAndIncIP();
 
 	bool SetPreviousBodyIP(int setToIP);
 	int GetPreviousBodyIP();
@@ -82,8 +82,8 @@ public:
 	bool NestSelfPointer(RefCountedObject* pSelf);
 	bool UnnestSelfPointer();
 	RefCountedObject* GetCurrentSelfPter();
-	bool* GetPointerToBoolStateVariable(int index) { return boolStates + index; }
-	int64_t* GetPointerToIntStateVariable(int index) { return intStates + index; }
+	WordBodyElement** GetPointerToBoolStateVariable(int index) { return boolStates + index; }
+	WordBodyElement** GetPointerToIntStateVariable(int index) { return intStates + index; }
 
 public:
 	ForthDict* pDict;
@@ -118,6 +118,6 @@ public:
 
 private:
 	static const int c_maxStates = 10;
-	bool boolStates[c_maxStates];
-	int64_t intStates[c_maxStates];
+	WordBodyElement* boolStates[c_maxStates];
+	WordBodyElement* intStates[c_maxStates];
 };

--- a/SmallForth/ExecState.h
+++ b/SmallForth/ExecState.h
@@ -32,9 +32,8 @@ public:
 	WordBodyElement** GetNextWordPterFromCurrentBodyAndIncIP();
 	WordBodyElement* GetWordAtOffsetFromCurrentBody(int offset);
 	WordBodyElement** GetWordPterAtOffsetFromCurrentBody(int offset);
-
 	WordBodyElement** GetNextWordFromPreviousNestedBodyAndIncIP();
-	//WordBodyElement** GetNextWordPterFromPreviousNestedBodyAndIncIP();
+	bool CurrentBodyIsInLastCompiledWord();
 
 	bool SetPreviousBodyIP(int setToIP);
 	int GetPreviousBodyIP();

--- a/SmallForth/ForthDefs.h
+++ b/SmallForth/ForthDefs.h
@@ -51,12 +51,12 @@ enum BinaryOperationType {
 };
 
 union WordBodyElement {
+
 	XT wordElement_XT;
 	int64_t wordElement_int;
 	double wordElement_float;
 	bool wordElement_bool;
 	char wordElement_char;
-	ValueType wordElement_type;
 	WordBodyElement** wordElement_BodyPter;
 	void* pter;
 	ForthType forthType;

--- a/SmallForth/ForthWord.cpp
+++ b/SmallForth/ForthWord.cpp
@@ -83,16 +83,9 @@ void ForthWord::CompileLiteralIntoWord(double literal) {
 	GrowByAndAdd(1, pNewElement);
 }
 
-void ForthWord::CompileLiteralIntoWord(ValueType literal) {
-	WordBodyElement* pNewElement = new WordBodyElement();
-	pNewElement->wordElement_type = literal;
-	GrowByAndAdd(1, pNewElement);
-}
-
 void ForthWord::CompileLiteralIntoWord(WordBodyElement* literal) {
 	GrowByAndAdd(1, literal);
 }
-
 
 void ForthWord::CompileTypeIntoWord(ForthType forthType) {
 	WordBodyElement* pNewElement = new WordBodyElement();
@@ -222,7 +215,7 @@ bool ForthWord::BuiltIn_DescribeWord(ExecState* pExecState) {
 				ForthWord* pWord = pExecState->pDict->FindWordFromCFAPter(pEl->wordElement_BodyPter);
 				if (pWord == nullptr) {
 					if (upcomingWordIsLiteralType) {
-						upcomingWordType = pEl->wordElement_type;
+						upcomingWordType = pEl->forthType;
 						string typeDescription = pTS->TypeToString(upcomingWordType);
 						(*pStdoutStream) << ip << ":  literal type (" << typeDescription << ")" << endl;
 						upcomingWordIsLiteralType = false;

--- a/SmallForth/ForthWord.h
+++ b/SmallForth/ForthWord.h
@@ -20,8 +20,6 @@ public:
 	void CompileLiteralIntoWord(char literal);
 	void CompileLiteralIntoWord(int64_t literal);
 	void CompileLiteralIntoWord(double literal);
-	void CompileLiteralIntoWord(ValueType literal);
-//	void CompileLiteralIntoWord(RefCountedObject* literal);
 	void CompileLiteralIntoWord(WordBodyElement* literal);
 	void CompileTypeIntoWord(ForthType forthType);
 	void CompilePterIntoWord(void* pter);

--- a/SmallForth/ForthWordBuiltInHelpers.cpp
+++ b/SmallForth/ForthWordBuiltInHelpers.cpp
@@ -63,6 +63,18 @@ bool ForthWord::BuiltInHelper_BinaryOperation(ExecState* pExecState, BinaryOpera
 			return pExecState->CreateException("Unsupported operation on types");
 		}
 	}
+	else if (pTS->IsPter(type1) && type2 == StackElement_Int) {
+		int64_t n2 = pElement2->GetInt();
+		// Cannot do pointer arithmetic on a void*
+		int64_t* pObject1 = (int64_t*)pElement1->GetContainedPter();
+		switch (opType) {
+		case BinaryOp_Add: pNewElement = new StackElement(type1, pObject1 + n2); break;
+		case BinaryOp_Subtract: pNewElement = new StackElement(type1, pObject1 - n2); break;
+		default:
+			BuiltInHelper_DeleteOperands(pElement1, pElement2);
+			return pExecState->CreateException("Unsupported operation on pter");
+		}
+	}
 	else if (type1 == StackElement_Int || type2 == StackElement_Int) {
 		if (!TypeSystem::CanConvertToInt(type1) || !TypeSystem::CanConvertToInt(type2)) {
 			BuiltInHelper_DeleteOperands(pElement1, pElement2);

--- a/SmallForth/ForthWordBuiltInHelpers.cpp
+++ b/SmallForth/ForthWordBuiltInHelpers.cpp
@@ -260,12 +260,12 @@ bool ForthWord::BuiltInHelper_FetchLiteralWithOffset(ExecState* pExecState, int 
 	if (pWBE_Type == nullptr) {
 		return pExecState->CreateException("Cannot fetch literal as cannot find a literal type in word body");
 	}
-	WordBodyElement* pWBE_Word = pExecState->GetWordAtOffsetFromCurrentBody(offset + 2);
-	if (pWBE_Word == nullptr) {
+	WordBodyElement** ppWBE_Word = pExecState->GetWordPterAtOffsetFromCurrentBody(offset + 2);
+	if (ppWBE_Word == nullptr) {
 		return pExecState->CreateException("Cannot fetch literal as cannot find a literal in word body");
 	}
-	ValueType toPush = pWBE_Word->wordElement_type;
-	if (!pExecState->pStack->Push(new StackElement(pWBE_Type->forthType, pWBE_Word))) {
+//	ValueType toPush = (*ppWBE_Word)->wordElement_type;
+	if (!pExecState->pStack->Push(new StackElement(pWBE_Type->forthType, ppWBE_Word))) {
 		return pExecState->CreateStackOverflowException();
 	}
 	return true;
@@ -283,6 +283,7 @@ bool ForthWord::BuiltInHelper_CompileTOSLiteral(ExecState* pExecState, bool incl
 	}
 	else {
 		pExecState->pCompiler->CompileTypeIntoWordBeingCreated(pExecState, pTopElement->GetType());
+
 		pExecState->pCompiler->CompileWBEIntoWordBeingCreated(pExecState, pTopElement->GetValueAsWordBodyElement());
 	}
 

--- a/SmallForth/InputProcessor.cpp
+++ b/SmallForth/InputProcessor.cpp
@@ -181,7 +181,7 @@ bool InputProcessor::Interpret(ExecState* pExecState) {
 					pExecState->SetVariable("#postponestate", false);
 					pExecState->SetVariable("#compileState", (int64_t)0);
 					pExecState->SetVariable("#insideComment", false);
-					pExecState->SetVariable("#insideLineComment", false);
+					pExecState->SetVariable("#insideCommentLine", false);
 				}
 			}
 		}

--- a/SmallForth/PreBuiltWords.cpp
+++ b/SmallForth/PreBuiltWords.cpp
@@ -894,9 +894,9 @@ bool PreBuiltWords::BuiltIn_Allot(ExecState* pExecState) {
 	delete pElementAllotBy;
 	pElementAllotBy = nullptr;//
 
-	pExecState->pCompiler->ExpandLastWordCompiledBy(pExecState, (int)n);
+	bool success = pExecState->pCompiler->ExpandLastWordCompiledBy(pExecState, (int)n);
 
-	return true;
+	return success;
 }
 
 bool PreBuiltWords::BuiltIn_Reveal(ExecState* pExecState) {
@@ -1845,6 +1845,10 @@ bool PreBuiltWords::BuiltIn_PushPter(ExecState* pExecState) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
 	WordBodyElement** ppWBE_Type = pExecState->GetWordPterAtOffsetFromCurrentBody(1);
 	WordBodyElement** ppWBE_Literal = pExecState->GetWordPterAtOffsetFromCurrentBody(2);
+	if (pExecState->CurrentBodyIsInLastCompiledWord()) {
+		// 
+		pExecState->pCompiler->ForgetLastCompiledWord();
+	}
 
 	if (ppWBE_Type == nullptr || ppWBE_Literal == nullptr) {
 		return pExecState->CreateException("Cannot push a pointer a word-contained literal, as has to have both a type and a literal value");

--- a/SmallForth/PreBuiltWords.cpp
+++ b/SmallForth/PreBuiltWords.cpp
@@ -442,9 +442,9 @@ bool PreBuiltWords::BuiltIn_ThreadSafeBoolVariable(ExecState* pExecState) {
 	delete pElementIndex;
 	pElementIndex = nullptr;
 
-	bool* pVar = pExecState->GetPointerToBoolStateVariable(index);
+	WordBodyElement** ppWBE = pExecState->GetPointerToBoolStateVariable(index);
 	ForthType pterType = pTS->CreatePointerTypeTo(StackElement_Bool);
-	StackElement* pElementVariable = new StackElement(pterType, (void*)pVar);
+	StackElement* pElementVariable = new StackElement(pterType, ppWBE);
 	if (!pExecState->pStack->Push(pElementVariable)) {
 		return pExecState->CreateStackOverflowException("whilst pushing a state boolean variable");
 	}
@@ -466,9 +466,9 @@ bool PreBuiltWords::BuiltIn_ThreadSafeIntVariable(ExecState* pExecState) {
 	delete pElementIndex;
 	pElementIndex = nullptr;
 
-	int64_t* pVar = pExecState->GetPointerToIntStateVariable(index);
+	WordBodyElement** ppWBE = pExecState->GetPointerToIntStateVariable(index);
 	ForthType pterType = pTS->CreatePointerTypeTo(StackElement_Int);
-	StackElement* pElementVariable = new StackElement(pterType, (void*)pVar);
+	StackElement* pElementVariable = new StackElement(pterType, ppWBE);
 	if (!pExecState->pStack->Push(pElementVariable)) {
 		return pExecState->CreateStackOverflowException("whilst pushing a state int variable");
 	}
@@ -478,9 +478,9 @@ bool PreBuiltWords::BuiltIn_ThreadSafeIntVariable(ExecState* pExecState) {
 bool PreBuiltWords::BuiltIn_CompileState(ExecState* pExecState) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
 
-	int64_t* pVar = pExecState->GetPointerToIntStateVariable(ExecState::c_compileStateIndex);
+	WordBodyElement** ppWBE = pExecState->GetPointerToIntStateVariable(ExecState::c_compileStateIndex);
 	ForthType pterType = pTS->CreatePointerTypeTo(StackElement_Int);
-	StackElement* pElementVariable = new StackElement(pterType, (void*)pVar);
+	StackElement* pElementVariable = new StackElement(pterType, ppWBE);
 	if (!pExecState->pStack->Push(pElementVariable)) {
 		return pExecState->CreateStackOverflowException("whilst pushing a state int variable");
 	}
@@ -490,9 +490,9 @@ bool PreBuiltWords::BuiltIn_CompileState(ExecState* pExecState) {
 bool PreBuiltWords::BuiltIn_PostponeState(ExecState* pExecState) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
 
-	bool* pVar = pExecState->GetPointerToBoolStateVariable(ExecState::c_postponedExecIndex);
+	WordBodyElement** ppWBE = pExecState->GetPointerToBoolStateVariable(ExecState::c_postponedExecIndex);
 	ForthType pterType = pTS->CreatePointerTypeTo(StackElement_Bool);
-	StackElement* pElementVariable = new StackElement(pterType, (void*)pVar);
+	StackElement* pElementVariable = new StackElement(pterType, ppWBE);
 	if (!pExecState->pStack->Push(pElementVariable)) {
 		return pExecState->CreateStackOverflowException("whilst pushing a state boolean variable");
 	}
@@ -502,9 +502,9 @@ bool PreBuiltWords::BuiltIn_PostponeState(ExecState* pExecState) {
 bool PreBuiltWords::BuiltIn_InsideCommentState(ExecState* pExecState) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
 
-	bool* pVar = pExecState->GetPointerToBoolStateVariable(ExecState::c_insideCommentIndex);
+	WordBodyElement** ppWBE = pExecState->GetPointerToBoolStateVariable(ExecState::c_insideCommentIndex);
 	ForthType pterType = pTS->CreatePointerTypeTo(StackElement_Bool);
-	StackElement* pElementVariable = new StackElement(pterType, (void*)pVar);
+	StackElement* pElementVariable = new StackElement(pterType, ppWBE);
 	if (!pExecState->pStack->Push(pElementVariable)) {
 		return pExecState->CreateStackOverflowException("whilst pushing a state boolean variable");
 	}
@@ -514,9 +514,9 @@ bool PreBuiltWords::BuiltIn_InsideCommentState(ExecState* pExecState) {
 bool PreBuiltWords::BuiltIn_InsideCommentLineState(ExecState* pExecState) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
 
-	bool* pVar = pExecState->GetPointerToBoolStateVariable(ExecState::c_insideCommentLineIndex);
+	WordBodyElement** ppWBE = pExecState->GetPointerToBoolStateVariable(ExecState::c_insideCommentLineIndex);
 	ForthType pterType = pTS->CreatePointerTypeTo(StackElement_Bool);
-	StackElement* pElementVariable = new StackElement(pterType, (void*)pVar);
+	StackElement* pElementVariable = new StackElement(pterType, ppWBE);
 	if (!pExecState->pStack->Push(pElementVariable)) {
 		return pExecState->CreateStackOverflowException("whilst pushing a state boolean variable");
 	}
@@ -1788,8 +1788,6 @@ bool PreBuiltWords::BuiltIn_Sqrt(ExecState* pExecState) {
 	return true;
 }
 
-
-
 bool PreBuiltWords::BuiltIn_Peek(ExecState* pExecState) {
 	StackElement* pElementAddress = pExecState->pStack->TopElement();
 
@@ -1853,72 +1851,9 @@ bool PreBuiltWords::BuiltIn_PushPter(ExecState* pExecState) {
 	}
 	ForthType currentType = (*ppWBE_Type)->forthType;
 	ForthType pointerType = pTS->CreatePointerTypeTo(currentType);
-	// Note: commenting this line and adding the next one, currently breaks peek and poke
-	void* pter = reinterpret_cast<void*>(ppWBE_Literal[0]);
-	//void* pter = reinterpret_cast<void*>(ppWBE_Literal);
+	//void* pter = reinterpret_cast<void*>(ppWBE_Literal[0]);
+	void* pter = reinterpret_cast<void*>(ppWBE_Literal);
 	StackElement* pNewStackElement = new StackElement(pointerType, pter);
-	if (!pExecState->pStack->Push(pNewStackElement)) {
-		return pExecState->CreateStackOverflowException();
-	}
-	return true;
-}
-
-bool PreBuiltWords::BuiltIn_PushFloatPter(ExecState* pExecState) {
-	WordBodyElement** ppWBE = pExecState->GetWordPterAtOffsetFromCurrentBody(1);
-
-	double* pValue = &(*ppWBE)->wordElement_float;
-
-	StackElement* pNewStackElement = new StackElement(pValue);
-	if (!pExecState->pStack->Push(pNewStackElement)) {
-		return pExecState->CreateStackOverflowException();
-	}
-	return true;
-}
-
-bool PreBuiltWords::BuiltIn_PushIntPter(ExecState* pExecState) {
-	WordBodyElement** ppWBE = pExecState->GetWordPterAtOffsetFromCurrentBody(1);
-
-	int64_t* pValue = &(*ppWBE)->wordElement_int;
-
-	StackElement* pNewStackElement = new StackElement(pValue);
-	if (!pExecState->pStack->Push(pNewStackElement)) {
-		return pExecState->CreateStackOverflowException();
-	}
-	return true;
-}
-
-bool PreBuiltWords::BuiltIn_PushCharPter(ExecState* pExecState) {
-	WordBodyElement** ppWBE = pExecState->GetWordPterAtOffsetFromCurrentBody(1);
-
-	char* pValue = &(*ppWBE)->wordElement_char;
-
-	StackElement* pNewStackElement = new StackElement(pValue);
-	if (!pExecState->pStack->Push(pNewStackElement)) {
-		return pExecState->CreateStackOverflowException();
-	}
-	return true;
-}
-
-bool PreBuiltWords::BuiltIn_PushBoolPter(ExecState* pExecState) {
-	WordBodyElement** ppWBE = pExecState->GetWordPterAtOffsetFromCurrentBody(1);
-
-	bool* pValue = &(*ppWBE)->wordElement_bool;
-
-	StackElement* pNewStackElement = new StackElement(pValue);
-	if (!pExecState->pStack->Push(pNewStackElement)) {
-		return pExecState->CreateStackOverflowException();
-	}
-	return true;
-}
-
-// Push the pointer to word one of the current word, as a pointer to a type.
-//  Used by VARIABLE, when the variable contained is a type
-bool PreBuiltWords::BuiltIn_PushTypePter(ExecState* pExecState) {
-	WordBodyElement** ppWBE = pExecState->GetWordPterAtOffsetFromCurrentBody(1);
-
-	ValueType* pValue = &(*ppWBE)->wordElement_type;
-
-	StackElement* pNewStackElement = new StackElement(pValue);
 	if (!pExecState->pStack->Push(pNewStackElement)) {
 		return pExecState->CreateStackOverflowException();
 	}
@@ -2009,17 +1944,17 @@ bool PreBuiltWords::BuiltIn_FetchLiteral(ExecState* pExecState) {
 }
 
 bool PreBuiltWords::BuiltIn_PushUpcomingLiteral(ExecState* pExecState) {
-	WordBodyElement* pWBE_Type = pExecState->GetNextWordFromPreviousNestedBodyAndIncIP();
-	if (pWBE_Type == nullptr) {
+	WordBodyElement** ppWBE_Type = pExecState->GetNextWordFromPreviousNestedBodyAndIncIP();
+	if (ppWBE_Type == nullptr) {
 		return pExecState->CreateException("Push literal cannot find a literal type in word body");
 	}
-	WordBodyElement* pWBE_Literal = pExecState->GetNextWordFromPreviousNestedBodyAndIncIP();
-	if (pWBE_Literal == nullptr) {
+	WordBodyElement** ppWBE_Literal = pExecState->GetNextWordFromPreviousNestedBodyAndIncIP();
+	if (ppWBE_Literal == nullptr) {
 		return pExecState->CreateException("Push literal cannot find a literal in word body");
 	}
-	ForthType forthType = pWBE_Type->forthType;
+	ForthType forthType = (*ppWBE_Type)->forthType;
 
-	if (!pExecState->pStack->Push(new StackElement(forthType, pWBE_Literal))) {
+	if (!pExecState->pStack->Push(new StackElement(forthType, ppWBE_Literal))) {
 		return pExecState->CreateStackOverflowException();
 	}
 	return true;

--- a/SmallForth/PreBuiltWords.h
+++ b/SmallForth/PreBuiltWords.h
@@ -141,11 +141,6 @@ public:
 	// Pointers
 	static bool BuiltIn_Peek(ExecState* pExecState);
 	static bool BuiltIn_Poke(ExecState* pExecState);
-	static bool BuiltIn_PushFloatPter(ExecState* pExecState);
-	static bool BuiltIn_PushIntPter(ExecState* pExecState);
-	static bool BuiltIn_PushCharPter(ExecState* pExecState);
-	static bool BuiltIn_PushBoolPter(ExecState* pExecState);
-	static bool BuiltIn_PushTypePter(ExecState* pExecState);
 	static bool BuiltIn_PushPter(ExecState* pExecState);
 
 	// Variables, constants and literals

--- a/SmallForth/StackElement.h
+++ b/SmallForth/StackElement.h
@@ -19,7 +19,7 @@ public:
 //	StackElement(WordBodyElement*** pppWbe);
 	StackElement(ForthType v);
 	StackElement(RefCountedObject* pObject);
-	StackElement(ForthType forthType, WordBodyElement* pLiteral);
+	StackElement(ForthType forthType, WordBodyElement** ppLiteral);
 	StackElement(ForthType forthType, void* pter);
 	~StackElement();
 

--- a/SmallForth/TypeSystem.cpp
+++ b/SmallForth/TypeSystem.cpp
@@ -237,13 +237,12 @@ tuple<ForthType, void*> TypeSystem::DeferencePointer(ForthType type, void* pter)
 	}
 	else {
 		if (indirectionCount > 1) {
-			WordBodyElement** ppWBE = reinterpret_cast<WordBodyElement**>(pter);
-			void* pValue = &(*ppWBE)->pter;
-
 			--indirectionCount;
-			ForthType newForthType = (indirectionCount << 16) | GetValueType(type);
 
-			return { newForthType, pValue };
+			WordBodyElement** ppWBE = reinterpret_cast<WordBodyElement**>(pter);
+			void* pterInWBE = (*ppWBE)->pter;
+			ForthType newForthType = (indirectionCount << 16) | GetValueType(type);
+			return { newForthType, pterInWBE };
 		}
 		else {
 			--indirectionCount;

--- a/SmallForth/TypeSystem.h
+++ b/SmallForth/TypeSystem.h
@@ -56,7 +56,6 @@ public:
 	void DecReferenceForPterBy(ForthType type, void* pter, int by);
 	tuple<bool, void*> DeferencePointerToObjectPter(ForthType type, void* pter) const;
 	tuple<bool, const void*> DeferencePointerToObjectPter(ForthType type, const void* pter) const;
-	tuple<bool, void*> DeferencePointerToValuePter(ForthType type, void* pter) const;
 	tuple<bool, const void*> DeferencePointerToValuePter(ForthType type, const void* pter) const;
 	tuple<ForthType, void*> DeferencePointer(ForthType type, void* pter);
 	bool ValueCompatibleWithAddress(ForthType addressType, ForthType valueType, bool directAssignment) const;


### PR DESCRIPTION
Update code to have all references to Words (where, not only code, but variables are stored) reference the WordBodyElement** array, not the individual contained WordBodyElement* in this array.
This allows pointer arithmetic to be performed.  Storing a pter to the WBE** on the allows the pointer to be advanced to the next element in the array.
This is complicated by the fact that these pointers are stored as void*, as they could refer to RefCountedObject*, or WordBodyElement* (now **).  Avoiding the C++ type system like this has caused issues, and it is recommended to alter WordBodyElement from a union to a class, and add some type safety.