### PR TITLE
Merge performance improvements

### DIFF
--- a/SmallForth/ExecState.cpp
+++ b/SmallForth/ExecState.cpp
@@ -342,6 +342,16 @@ bool ExecState::GetVariable(const string& variableName, int64_t& variableValue) 
 	return false;
 }
 
+bool ExecState::GetBoolTLSVariable(int index) {
+	WordBodyElement* pWBE = this->boolStates[index];
+	return pWBE->wordElement_bool;
+}
+
+int64_t ExecState::GetIntTLSVariable(int index) {
+	WordBodyElement* pWBE = this->intStates[index];
+	return pWBE->wordElement_int;
+}
+
 bool ExecState::GetVariable(const string& variableName, double& variableValue) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
 	if (!this->ExecuteWordDirectly(variableName)) {

--- a/SmallForth/ExecState.h
+++ b/SmallForth/ExecState.h
@@ -55,6 +55,8 @@ public:
 	bool GetVariable(const string& variableName, double& variableValue);
 	bool GetVariable(const string& variableName, bool& variableValue);
 	bool GetVariable(const string& variableName, ForthType& variableValue);
+	bool GetBoolTLSVariable(int index);
+	int64_t GetIntTLSVariable(int index);
 
 	bool PushConstantOntoStack(const string& constantName);
 	bool GetConstant(const string& constantName, int64_t& constantValue);

--- a/SmallForth/ForthWordBuiltInHelpers.cpp
+++ b/SmallForth/ForthWordBuiltInHelpers.cpp
@@ -243,8 +243,7 @@ bool ForthWord::BuiltInHelper_GetThreeStackElements(ExecState* pExecState, Stack
 // Relies on return stack TOS have the index into the word being defines literal element
 //  (The actual pushlit that preceeds the actual value - it will have 1 added to it)
 bool ForthWord::BuiltInHelper_UpdateForwardJump(ExecState* pExecState) {
-	int64_t nCompileState;
-	pExecState->GetVariable("#compileState", nCompileState);
+	int64_t nCompileState = pExecState->GetIntTLSVariable(ExecState::c_compileStateIndex);
 
 	if (nCompileState == 0) {
 		return pExecState->CreateException("Cannot update forward jump when not compiling");

--- a/SmallForth/ForthWordObjectHandling.cpp
+++ b/SmallForth/ForthWordObjectHandling.cpp
@@ -46,8 +46,7 @@ bool PreBuiltWords::BuiltIn_StringLiteral(ExecState* pExecState) {
 	}
 	ForthString* pForthString = new ForthString(literal);
 
-	int64_t nCompileState;
-	pExecState->GetVariable("#compileState", nCompileState);
+	int64_t nCompileState = pExecState->GetIntTLSVariable(ExecState::c_compileStateIndex);
 
 	if (nCompileState == 1) {
 		pExecState->pCompiler->CompilePushAndLiteralIntoWordBeingCreated(pExecState, pForthString);

--- a/SmallForth/InputProcessor.cpp
+++ b/SmallForth/InputProcessor.cpp
@@ -40,15 +40,13 @@ tuple<ForthWord*, bool> InputProcessor::GetForthWordFromVocabOrObject(ExecState*
 	bool executeOnTOSObject = false;
 	InputWord wordWithDelimiterCount = GetNextWord(pExecState);
 	string wordName = wordWithDelimiterCount.word;
-	bool bInsideCommentLine;
-	pExecState->GetVariable("#insideCommentLine", bInsideCommentLine);
+	bool bInsideCommentLine = pExecState->GetBoolTLSVariable(ExecState::c_insideCommentLineIndex);
 	if (bInsideCommentLine || wordName.length() == 0) {
 		return { nullptr, executeOnTOSObject };
 	}
 	pExecState->delimitersAfterCurrentWord = wordWithDelimiterCount.postDelimiterCount;
 	ForthWord* pWord = nullptr;
-	int64_t nCompileState;
-	pExecState->GetVariable("#compileState", nCompileState);
+	int64_t nCompileState = pExecState->GetIntTLSVariable(ExecState::c_compileStateIndex);
 
 	if (pExecState->nextWordIsCharLiteral) {
 		pExecState->nextWordIsCharLiteral = false;
@@ -72,8 +70,7 @@ tuple<ForthWord*, bool> InputProcessor::GetForthWordFromVocabOrObject(ExecState*
 		{
 			pWord = pExecState->pDict->FindWord(wordName);
 			if (pWord == nullptr) {
-				bool bInsideComment;
-				pExecState->GetVariable("#insideComment", bInsideComment);
+				bool bInsideComment = pExecState->GetBoolTLSVariable(ExecState::c_insideCommentIndex);
 
 				if (bInsideComment == false) {
 					int64_t intValue;
@@ -123,8 +120,7 @@ bool InputProcessor::Interpret(ExecState* pExecState) {
 			}
 			continue;
 		}
-		bool bInsideComment;
-		pExecState->GetVariable("#insideComment", bInsideComment);
+		bool bInsideComment = pExecState->GetBoolTLSVariable(ExecState::c_insideCommentIndex);
 
 		if (bInsideComment && WordMatchesXT(pWord, PreBuiltWords::BuiltIn_ParenthesisCommentEnd) == false)
 		{
@@ -140,14 +136,12 @@ bool InputProcessor::Interpret(ExecState* pExecState) {
 			continue;
 		}
 
-		int64_t nCompileState;
-		pExecState->GetVariable("#compileState", nCompileState);
+		int64_t nCompileState = pExecState->GetIntTLSVariable(ExecState::c_compileStateIndex);
 
 		try {
 			bool executeWordNow = false;
 			if (nCompileState==1) {
-				bool bExecutePostponed;
-				pExecState->GetVariable("#postponeState", bExecutePostponed);
+				bool bExecutePostponed = pExecState->GetBoolTLSVariable(ExecState::c_postponedExecIndex);
 				if (pWord->GetImmediate() && !bExecutePostponed) {
 					executeWordNow = true;
 				}
@@ -246,15 +240,13 @@ void InputProcessor::ReadAndProcess(ExecState* pExecState) {
 	ostream* pStdout = pExecState->GetStdout();
 	istream* pStdin = pExecState->GetStdin();
 
-	int64_t nCompileState;
-	pExecState->GetVariable("#compileState", nCompileState);
+	int64_t nCompileState = pExecState->GetIntTLSVariable(ExecState::c_compileStateIndex);
 
 	try
 	{
 		while (true) {
 			std::string line;
-			bool bInsideComment;
-			pExecState->GetVariable("#insideComment", bInsideComment);
+			bool bInsideComment = pExecState->GetBoolTLSVariable(ExecState::c_insideCommentIndex);
 
 			if (bInsideComment) {
 				(*pStdout) << pExecState->commentPrompt;
@@ -728,8 +720,7 @@ bool InputProcessor::ConvertToFloat(const string& word, double& n) {
 ForthWord* InputProcessor::FindWordInTOSWord(ExecState* pExecState, const string& wordName) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
 	StackElement* pElement = pExecState->pStack->TopElement();
-	int64_t nCompileState;
-	pExecState->GetVariable("#compileState", nCompileState);
+	int64_t nCompileState = pExecState->GetIntTLSVariable(ExecState::c_compileStateIndex);
 
 	if (pElement != nullptr) {
 		ForthType tosType = pElement->GetType();

--- a/SmallForth/PreBuiltWords.cpp
+++ b/SmallForth/PreBuiltWords.cpp
@@ -172,6 +172,9 @@ void PreBuiltWords::RegisterWords(ForthDict* pDict) {
 
 	InitialiseWord(pDict, "isObject", PreBuiltWords::IsObject);
 	InitialiseWord(pDict, "isPter", PreBuiltWords::IsPter);
+
+	// Timer and time
+	InitialiseWord(pDict, "elapsedSeconds", PreBuiltWords::BuiltIn_GetHighResolutionTime);
 }
 
 void PreBuiltWords::CreateSecondLevelWords(ExecState* pExecState) {
@@ -579,11 +582,9 @@ bool PreBuiltWords::BuiltIn_DoCol(ExecState* pExecState) {
 		//  it would compile the EXIT and continue past into undefined behaviour.
 
 
-		bool bExecutePostponed;
-		pExecState->GetVariable("#postponeState", bExecutePostponed);
+		bool bExecutePostponed = pExecState->GetBoolTLSVariable(ExecState::c_postponedExecIndex);
 		if (bExecutePostponed) {
-			int64_t nCompileState;
-			pExecState->GetVariable("#compileState", nCompileState);
+			int64_t nCompileState = pExecState->GetIntTLSVariable(ExecState::c_compileStateIndex);
 
 			if (!pExecState->SetVariable("#postponeState", false)) {
 				return pExecState->CreateException("Could not reset postpone state flag");
@@ -775,8 +776,7 @@ bool PreBuiltWords::BuiltIn_JumpOnFalse(ExecState* pExecState) {
 
 // ( addr:value -- ) *addr=value
 bool PreBuiltWords::BuiltIn_PokeIntegerInWord(ExecState* pExecState) {
-	int64_t nCompileState;
-	pExecState->GetVariable("#compileState", nCompileState);
+	int64_t nCompileState = pExecState->GetIntTLSVariable(ExecState::c_compileStateIndex);
 	if (nCompileState==0) {
 		return pExecState->CreateException("Cannot execute !INWORD when not compiling");
 	}
@@ -878,7 +878,6 @@ bool PreBuiltWords::BuiltIn_LineCommentStart(ExecState* pExecState) {
 	}
 	return true;
 }
-
 
 bool PreBuiltWords::BuiltIn_Allot(ExecState* pExecState) {
 	StackElement* pElementAllotBy = pExecState->pStack->Pull();
@@ -1934,8 +1933,7 @@ bool PreBuiltWords::BuiltIn_LiteralNoPush(ExecState* pExecState) {
 
 
 bool PreBuiltWords::BuiltIn_CharLiteral(ExecState* pExecState) {
-	int64_t nCompileState;
-	pExecState->GetVariable("#compileState", nCompileState);
+	int64_t nCompileState = pExecState->GetIntTLSVariable(ExecState::c_compileStateIndex);
 	if (nCompileState==0) {
 		return true;
 	}
@@ -1965,8 +1963,8 @@ bool PreBuiltWords::BuiltIn_PushUpcomingLiteral(ExecState* pExecState) {
 }
 
 bool PreBuiltWords::BuiltIn_UpdateForwardJump(ExecState* pExecState) {
-	int64_t nCompileState;
-	pExecState->GetVariable("#compileState", nCompileState);
+	int64_t nCompileState = pExecState->GetIntTLSVariable(ExecState::c_compileStateIndex);
+	
 	if (nCompileState == 0) {
 		return pExecState->CreateException("Cannot execute UPDATEFORWARDJUMP when not compiling");
 	}
@@ -1983,4 +1981,15 @@ bool PreBuiltWords::BuiltIn_ThrowException(ExecState* pExecState) {
 	else {
 		return pExecState->CreateException("Could not retrieve string to make exception of");
 	}
+}
+
+bool PreBuiltWords::BuiltIn_GetHighResolutionTime(ExecState* pExecState) {
+	int64_t freq = _Query_perf_frequency();
+	int64_t time = _Query_perf_counter();
+
+	double elapsedSeconds = (double)time / (double)freq;
+	if (!pExecState->pStack->Push(elapsedSeconds)) {
+		return pExecState->CreateStackOverflowException("whilst getting high resolution time");
+	}
+	return true;
 }

--- a/SmallForth/PreBuiltWords.cpp
+++ b/SmallForth/PreBuiltWords.cpp
@@ -281,7 +281,7 @@ void PreBuiltWords::CreateSecondLevelWords(ExecState* pExecState) {
 	InterpretForth(pExecState, ": '\10' 10 tochar ; ");
 	InterpretForth(pExecState, ": pushNewLine '\10' ;");
 
-	InterpretForth(pExecState, ": dup2 dup dup ;"); // ( m -- m m)
+	InterpretForth(pExecState, ": dup2 dup dup ;"); // ( m -- m m m )
 	InterpretForth(pExecState, ": nip swap drop ;"); // ( m n -- n)
 	InterpretForth(pExecState, ": tuck swap over ;"); // ( m n -- n m n)
 	InterpretForth(pExecState, ": 2dup over over ;"); // ( m n -- m n m n)

--- a/SmallForth/PreBuiltWords.h
+++ b/SmallForth/PreBuiltWords.h
@@ -173,8 +173,10 @@ public:
 	// Control flow - most control flow is now defined in FORTH, but they use this to update forward jumps
 	static bool BuiltIn_UpdateForwardJump(ExecState* pExecState);
 
-
 	// Exceptions
 	static bool BuiltIn_ThrowException(ExecState* pExecState);
+
+	// Time, timers
+	static bool BuiltIn_GetHighResolutionTime(ExecState* pExecState);
 };
 

--- a/readme.md
+++ b/readme.md
@@ -111,11 +111,7 @@ There are three stacks accessible from Forth:
 
 ## Arrays
 
-Arrays are implemented as an object, instead of the normal Forth-style ```5 variable <array name> 5 cells allot``` . Ths is due to the way variables have to store the type information against the value it stores, and the way storing pointers to WordBodyElements inside stackelements is implemented.
-
-If this was required to be changed, all storing/accessing pters to WordBodyElements would need to be changed to WordBodyElement** instead of WordBodyElement*. Note, these are stored as void* inside the actual stackelements.
-
-Storing as WordBodyElement** would allow the pointer to the word elements to undergo pointer math.
+Dynamic arrays are implemented as an object,
 
 To construct an int array, with 5 as the first element, 6 as the 2nd, and 7 as the third. Then output the first two elements:
 
@@ -126,6 +122,10 @@ dup 0 swap [n] . cr
 dup 1 swap [n] . cr
 ```
  
+Static arrays are implemented as words:
+ ```5 variable <array name> 5 cells allot```
+
+ ```<array name> 1 swap +``` to move to first (0-based) element.
 
 ## Changes needed for assembly
 
@@ -215,7 +215,8 @@ The user-defined object system would need implementing in actual Forth too - imp
      : helloworld [char] ! [char] d  [char] l [char] r [char] o [char] W space  [char] o  [char] l dup  [char] e  [char] H emitall ;
 * ```NOT``` inverts binary at TOS
 * ```AND```, ```XOR```, ```OR``` binary operations on the top two booleans
-
+* ```ALLOT``` append additional space to the last defined word, allowing it to be used as a static array. (note, this has to be called immediately after defining the word)
+* ```ELAPSEDSECONDS``` get the number of elapsed seconds from the operating systems high resolution timer, as a double.
 
 
 ## Defining an object


### PR DESCRIPTION
Executing the forth version of get variable postpone state, in docol, was creating a 10x slowdown. This fixes that.