### PR TITLE
Stack improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,3 +361,4 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+/notes/stackimprovements.txt

--- a/SmallForth/DataStack.cpp
+++ b/SmallForth/DataStack.cpp
@@ -1,6 +1,7 @@
 #include "ForthDefs.h"
 #include "DataStack.h"
 #include "ForthString.h"
+#include "TypeSystem.h"
 
 // TODO Implement stack using forth
 
@@ -211,8 +212,25 @@ void* DataStack::PullAsVoidPter() {
 	return toReturn;
 }
 
+RefCountedObject* DataStack::PullAsObject() {
+	TypeSystem* pTS = TypeSystem::GetTypeSystem();
+
+	if (this->topOfStack == -1) {
+		return nullptr;
+	}
+	StackElement& el = this->stack[this->topOfStack];
+	RefCountedObject* pToReturn = nullptr;
+	if (!pTS->TypeIsObject(el.GetType())) {
+		return nullptr;
+	}
+	pToReturn = el.GetObject();
+	pToReturn->IncReference();
+	ShrinkStack();
+
+	return pToReturn;
+}
+
 std::tuple<bool, std::string> DataStack::PullAsString() {
-	double defaultValue = 0.0;
 	if (this->topOfStack == -1) {
 		return { false, "Stack underflow" };;
 	}

--- a/SmallForth/DataStack.cpp
+++ b/SmallForth/DataStack.cpp
@@ -152,6 +152,45 @@ int64_t DataStack::PullAsInt() {
 	return toReturn;
 }
 
+char DataStack::PullAsChar() {
+	char defaultValue = '\0';
+	if (this->topOfStack == -1) {
+		return defaultValue;
+	}
+
+	StackElement& el = this->stack[this->topOfStack];
+	char toReturn = el.GetChar();
+	ShrinkStack();
+
+	return toReturn;
+}
+
+double DataStack::PullAsFloat() {
+	double defaultValue = 0.0;
+	if (this->topOfStack == -1) {
+		return defaultValue;
+	}
+
+	StackElement& el = this->stack[this->topOfStack];
+	double toReturn = el.GetFloat();
+	ShrinkStack();
+
+	return toReturn;
+}
+
+ForthType DataStack::PullAsType() {
+	ForthType  defaultValue = StackElement_Undefined;
+	if (this->topOfStack == -1) {
+		return defaultValue;
+	}
+
+	StackElement& el = this->stack[this->topOfStack];
+	ForthType toReturn = el.GetValueType();
+	ShrinkStack();
+
+	return toReturn;
+}
+
 std::tuple<bool, std::string> DataStack::PullAsString() {
 	StackElement* pElement = Pull();
 	if (pElement == nullptr) {

--- a/SmallForth/DataStack.cpp
+++ b/SmallForth/DataStack.cpp
@@ -201,6 +201,26 @@ bool DataStack::TOSIsType(ElementType elementType) {
 	return tos.GetType() == elementType;
 }
 
+ForthType DataStack::GetTOSType() {
+	if (this->topOfStack == -1) {
+		return StackElement_Undefined;;
+	}
+	StackElement& tos = this->stack[this->topOfStack];
+	return tos.GetType();
+}
+
+bool DataStack::SwapTOS() {
+	if (this->topOfStack == 0) {
+		return false;
+	}
+	StackElement tos = this->stack[this->topOfStack];
+	StackElement nextStackElement = this->stack[this->topOfStack-1];
+	this->stack[this->topOfStack] = nextStackElement;
+	this->stack[this->topOfStack - 1] = tos;
+
+	return true;
+}
+
 StackElement* DataStack::TopElement() {
 	if (this->topOfStack == -1) {
 		return nullptr;

--- a/SmallForth/DataStack.cpp
+++ b/SmallForth/DataStack.cpp
@@ -188,7 +188,7 @@ double DataStack::PullAsFloat() {
 }
 
 ForthType DataStack::PullAsType() {
-	ForthType  defaultValue = StackElement_Undefined;
+	ForthType defaultValue = StackElement_Undefined;
 	if (this->topOfStack == -1) {
 		return defaultValue;
 	}
@@ -197,6 +197,17 @@ ForthType DataStack::PullAsType() {
 	ForthType toReturn = el.GetValueType();
 	ShrinkStack();
 
+	return toReturn;
+}
+
+WordBodyElement** DataStack::PullAsCFA() {
+	WordBodyElement** defaultValue = nullptr;
+	if (this->topOfStack == -1) {
+		return defaultValue;
+	}
+	StackElement& el = this->stack[this->topOfStack];
+	WordBodyElement** toReturn = el.GetWordBodyElement();
+	ShrinkStack();
 	return toReturn;
 }
 

--- a/SmallForth/DataStack.cpp
+++ b/SmallForth/DataStack.cpp
@@ -221,6 +221,24 @@ bool DataStack::SwapTOS() {
 	return true;
 }
 
+bool DataStack::DropTOS() {
+	if (this->topOfStack == -1) {
+		return false;
+	}
+	ShrinkStack();
+	return true;
+}
+
+bool DataStack::DupTOS() {
+	if (this->topOfStack == -1 || !MoveToNextSP()) {
+		return false;
+	}
+	StackElement tos = this->stack[this->topOfStack-1];
+	this->stack[this->topOfStack]=tos;
+	return true;
+}
+
+
 StackElement* DataStack::TopElement() {
 	if (this->topOfStack == -1) {
 		return nullptr;

--- a/SmallForth/DataStack.cpp
+++ b/SmallForth/DataStack.cpp
@@ -211,24 +211,23 @@ void* DataStack::PullAsVoidPter() {
 	return toReturn;
 }
 
-
 std::tuple<bool, std::string> DataStack::PullAsString() {
-	StackElement* pElement = Pull();
-	if (pElement == nullptr) {
-		return { false, "Stack underflow" };
+	double defaultValue = 0.0;
+	if (this->topOfStack == -1) {
+		return { false, "Stack underflow" };;
 	}
-	if (pElement->GetType() != ObjectType_String) {
-		delete pElement;
+
+	StackElement& el = this->stack[this->topOfStack];
+	if (el.GetType() != ObjectType_String) {
 		return { false, "No string on stack" };
 	}
-	ForthString* pForthString = (ForthString* )pElement->GetObject();
+	ForthString* pForthString = (ForthString*)el.GetObject();
 	std::string containedString = pForthString->GetContainedString();
-	delete pElement;
-	pElement = nullptr;
+	ShrinkStack();
 	return { true, containedString };
 }
 
-StackElement DataStack::PullAsRef() {
+StackElement DataStack::PullNoPter() {
 	if (this->topOfStack == -1) {
 		stack[0].RelinquishValue();
 		return stack[0];
@@ -240,7 +239,6 @@ StackElement DataStack::PullAsRef() {
 	ShrinkStack();
 
 	return toReturn;
-
 }
 
 std::tuple<bool, StackElement* > DataStack::PullType(ElementType type) {

--- a/SmallForth/DataStack.cpp
+++ b/SmallForth/DataStack.cpp
@@ -168,6 +168,21 @@ std::tuple<bool, std::string> DataStack::PullAsString() {
 	return { true, containedString };
 }
 
+StackElement DataStack::PullAsRef() {
+	if (this->topOfStack == -1) {
+		stack[0].RelinquishValue();
+		return stack[0];
+	}
+
+	StackElement& el = this->stack[this->topOfStack];
+	StackElement toReturn = std::move(el);
+
+	ShrinkStack();
+
+	return toReturn;
+
+}
+
 std::tuple<bool, StackElement* > DataStack::PullType(ElementType type) {
 	StackElement* pElement = Pull();
 	if (pElement == nullptr) {
@@ -254,7 +269,15 @@ bool DataStack::Push(StackElement* pElement) {
 	}
 	++this->topOfStack;
 	this->stack[this->topOfStack] = *pElement;
-	this->toDelete.push_back(pElement);
+	delete pElement;
+	return true;
+}
+
+bool DataStack::Push(const StackElement& element) {
+	if (!MoveToNextSP()) {
+		return false;
+	}
+	this->stack[this->topOfStack] = element;
 	return true;
 }
 

--- a/SmallForth/DataStack.cpp
+++ b/SmallForth/DataStack.cpp
@@ -62,6 +62,14 @@ bool DataStack::Push(bool value) {
 	return true;
 }
 
+bool DataStack::Push(BinaryOperationType value) {
+	if (!MoveToNextSP()) {
+		return false;
+	}
+	this->stack[this->topOfStack].SetTo(value);
+	return true;
+}
+
 bool DataStack::Push(ForthType value) {
 	if (!MoveToNextSP()) {
 		return false;
@@ -190,6 +198,19 @@ ForthType DataStack::PullAsType() {
 
 	return toReturn;
 }
+
+void* DataStack::PullAsVoidPter() {
+	void* defaultValue = nullptr;
+	if (this->topOfStack == -1) {
+		return defaultValue;
+	}
+
+	StackElement& el = this->stack[this->topOfStack];
+	void* toReturn = el.GetContainedPter();
+	ShrinkStack();
+	return toReturn;
+}
+
 
 std::tuple<bool, std::string> DataStack::PullAsString() {
 	StackElement* pElement = Pull();

--- a/SmallForth/DataStack.h
+++ b/SmallForth/DataStack.h
@@ -32,6 +32,9 @@ public:
 	StackElement* Pull();
 	bool PullAsBool();
 	int64_t PullAsInt();
+	char PullAsChar();
+	double PullAsFloat();
+	ForthType PullAsType();
 	StackElement PullAsRef();
 
 	std::tuple<bool, std::string> PullAsString();

--- a/SmallForth/DataStack.h
+++ b/SmallForth/DataStack.h
@@ -16,12 +16,18 @@ public:
 	bool Push(WordBodyElement** wordBodyPter);
 	bool Push(ForthType value);
 	bool Push(RefCountedObject* value);
+	bool Push(ForthType forthType, WordBodyElement** ppLiteral);
+	bool Push(ForthType forthType, void* pter);
 	bool Push(const std::string& value);
 
 	void Clear();
 
+	bool TOSIsType(ElementType elementType);
 	StackElement* TopElement();
 	StackElement* Pull();
+	bool PullAsBool();
+	int64_t PullAsInt();
+
 	std::tuple<bool, std::string> PullAsString();
 	std::tuple<StackElement*, StackElement* > PullTwo();
 	std::tuple<bool, StackElement* > PullType(ElementType type);
@@ -31,7 +37,10 @@ public:
 
 private:
 	bool MoveToNextSP();
-
+	inline void ShrinkStack() {
+		this->stack[this->topOfStack].RelinquishValue();
+		--this->topOfStack;
+	}
 
 private:
 	int stackSize;

--- a/SmallForth/DataStack.h
+++ b/SmallForth/DataStack.h
@@ -13,6 +13,7 @@ public:
 	bool Push(char value);
 	bool Push(double value);
 	bool Push(bool value);
+	bool Push(BinaryOperationType value);
 	bool Push(WordBodyElement** wordBodyPter);
 	bool Push(ForthType value);
 	bool Push(RefCountedObject* value);
@@ -35,6 +36,7 @@ public:
 	char PullAsChar();
 	double PullAsFloat();
 	ForthType PullAsType();
+	void* PullAsVoidPter();
 	StackElement PullAsRef();
 
 	std::tuple<bool, std::string> PullAsString();

--- a/SmallForth/DataStack.h
+++ b/SmallForth/DataStack.h
@@ -38,6 +38,8 @@ public:
 	ForthType PullAsType();
 	void* PullAsVoidPter();
 	StackElement PullNoPter();
+	RefCountedObject* PullAsObject();
+
 
 	std::tuple<bool, std::string> PullAsString();
 	std::tuple<StackElement*, StackElement* > PullTwo();

--- a/SmallForth/DataStack.h
+++ b/SmallForth/DataStack.h
@@ -32,15 +32,16 @@ public:
 	StackElement* Pull();
 	bool PullAsBool();
 	int64_t PullAsInt();
+	StackElement PullAsRef();
 
 	std::tuple<bool, std::string> PullAsString();
 	std::tuple<StackElement*, StackElement* > PullTwo();
 	std::tuple<bool, StackElement* > PullType(ElementType type);
 
 	bool Push(StackElement* pElement);
-	int Count() const { return topOfStack+1; }
+	bool Push(const StackElement& pElement);
 
-	int DeletedCount() const { return (int)this->toDelete.size(); }
+	int Count() const { return topOfStack+1; }
 
 private:
 	bool MoveToNextSP();
@@ -54,7 +55,6 @@ private:
 
 	std::vector<StackElement> stack;
 	int topOfStack;
-	std::vector<StackElement* > toDelete;
 
 //	std::stack<StackElement* > stack;
 };

--- a/SmallForth/DataStack.h
+++ b/SmallForth/DataStack.h
@@ -25,6 +25,8 @@ public:
 	bool TOSIsType(ElementType elementType);
 	ForthType GetTOSType();
 	bool SwapTOS();
+	bool DropTOS();
+	bool DupTOS();
 
 	StackElement* TopElement();
 	StackElement* Pull();
@@ -37,6 +39,8 @@ public:
 
 	bool Push(StackElement* pElement);
 	int Count() const { return topOfStack+1; }
+
+	int DeletedCount() const { return (int)this->toDelete.size(); }
 
 private:
 	bool MoveToNextSP();

--- a/SmallForth/DataStack.h
+++ b/SmallForth/DataStack.h
@@ -37,7 +37,7 @@ public:
 	double PullAsFloat();
 	ForthType PullAsType();
 	void* PullAsVoidPter();
-	StackElement PullAsRef();
+	StackElement PullNoPter();
 
 	std::tuple<bool, std::string> PullAsString();
 	std::tuple<StackElement*, StackElement* > PullTwo();

--- a/SmallForth/DataStack.h
+++ b/SmallForth/DataStack.h
@@ -36,6 +36,7 @@ public:
 	char PullAsChar();
 	double PullAsFloat();
 	ForthType PullAsType();
+	WordBodyElement** PullAsCFA();
 	void* PullAsVoidPter();
 	StackElement PullNoPter();
 	RefCountedObject* PullAsObject();

--- a/SmallForth/DataStack.h
+++ b/SmallForth/DataStack.h
@@ -23,6 +23,9 @@ public:
 	void Clear();
 
 	bool TOSIsType(ElementType elementType);
+	ForthType GetTOSType();
+	bool SwapTOS();
+
 	StackElement* TopElement();
 	StackElement* Pull();
 	bool PullAsBool();

--- a/SmallForth/DataStack.h
+++ b/SmallForth/DataStack.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <stack>
+#include <vector>
 #include <tuple>
 #include "StackElement.h"
 
@@ -27,12 +27,19 @@ public:
 	std::tuple<bool, StackElement* > PullType(ElementType type);
 
 	bool Push(StackElement* pElement);
-	int Count() const { return (int)stack.size(); }
+	int Count() const { return topOfStack+1; }
+
+private:
+	bool MoveToNextSP();
 
 
 private:
 	int stackSize;
 
-	std::stack<StackElement* > stack;
+	std::vector<StackElement> stack;
+	int topOfStack;
+	std::vector<StackElement* > toDelete;
+
+//	std::stack<StackElement* > stack;
 };
 

--- a/SmallForth/ExecState.cpp
+++ b/SmallForth/ExecState.cpp
@@ -325,19 +325,18 @@ bool ExecState::GetVariable(const std::string& variableName, int64_t& variableVa
 	if (!this->ExecuteWordDirectly(variableName)) {
 		return false;
 	}
-	StackElement* pElementVariableValuePter = this->pStack->TopElement();
+	ForthType topElementType = this->pStack->GetTOSType();
 	
-	if (pElementVariableValuePter->GetType() == pTS->CreatePointerTypeTo(StackElement_Int)) {
-		pElementVariableValuePter = nullptr;
+	if (topElementType == pTS->CreatePointerTypeTo(StackElement_Int)) {
 		if (this->ExecuteWordDirectly("@")) {
-			StackElement* pElementVariableValue;
-			pElementVariableValue = pStack->Pull();
-			if (pElementVariableValue == nullptr) {
-				return CreateStackOverflowException("whilst getting variable");
+			if (this->pStack->Count() == 0) {
+				return CreateStackOverflowException("whilst getting int variable");
 			}
-			variableValue = pElementVariableValue->GetInt();
-			delete pElementVariableValue;
-			pElementVariableValue = nullptr;
+			ForthType tosType = this->pStack->GetTOSType();
+			if (tosType != StackElement_Int && tosType != StackElement_Float && tosType != StackElement_Bool) {
+				return CreateException("Variable does not evaluate to an integer");
+			}
+			variableValue = pStack->PullAsInt();
 			return true;
 		}
 	}
@@ -359,19 +358,18 @@ bool ExecState::GetVariable(const std::string& variableName, double& variableVal
 	if (!this->ExecuteWordDirectly(variableName)) {
 		return false;
 	}
-	StackElement* pElementVariableValuePter = this->pStack->TopElement();
+	ForthType topElementType = this->pStack->GetTOSType();
 
-	if (pElementVariableValuePter->GetType() == pTS->CreatePointerTypeTo(StackElement_Float)) {
-		pElementVariableValuePter = nullptr;
+	if (topElementType ==  pTS->CreatePointerTypeTo(StackElement_Float)) {
 		if (this->ExecuteWordDirectly("@")) {
-			StackElement* pElementVariableValue;
-			pElementVariableValue = pStack->Pull();
-			if (pElementVariableValue == nullptr) {
-				return CreateStackOverflowException("whilst getting variable");
+			if (this->pStack->Count() == 0) {
+				return CreateStackOverflowException("whilst getting float variable");
 			}
-			variableValue = pElementVariableValue->GetFloat();
-			delete pElementVariableValue;
-			pElementVariableValue = nullptr;
+			ForthType tosType = this->pStack->GetTOSType();
+			if (tosType != StackElement_Int && tosType != StackElement_Float && tosType != StackElement_Bool) {
+				return CreateException("Variable does not evaluate to an float");
+			}
+			variableValue = pStack->PullAsFloat();
 			return true;
 		}
 	}
@@ -383,19 +381,18 @@ bool ExecState::GetVariable(const std::string& variableName, bool& variableValue
 	if (!this->ExecuteWordDirectly(variableName)) {
 		return false;
 	}
-	StackElement* pElementVariableValuePter = this->pStack->TopElement();
+	ForthType topElementType = this->pStack->GetTOSType();
 
-	if (pElementVariableValuePter->GetType() == pTS->CreatePointerTypeTo(StackElement_Bool)) {
-		pElementVariableValuePter = nullptr;
+	if (topElementType == pTS->CreatePointerTypeTo(StackElement_Bool)) {
 		if (this->ExecuteWordDirectly("@")) {
-			StackElement* pElementVariableValue;
-			pElementVariableValue = pStack->Pull();
-			if (pElementVariableValue == nullptr) {
-				return CreateStackOverflowException("whilst getting variable");
+			if (this->pStack->Count() == 0) {
+				return CreateStackOverflowException("whilst getting bool variable");
 			}
-			variableValue = pElementVariableValue->GetBool();
-			delete pElementVariableValue;
-			pElementVariableValue = nullptr;
+			ForthType tosType = this->pStack->GetTOSType();
+			if (tosType != StackElement_Bool) {
+				return CreateException("Variable does not evaluate to an bool");
+			}
+			variableValue = pStack->PullAsBool();
 			return true;
 		}
 	}
@@ -409,17 +406,18 @@ bool ExecState::GetVariable(const std::string& variableName, ForthType& variable
 	}
 	StackElement* pElementVariableValuePter = this->pStack->TopElement();
 
-	if (pElementVariableValuePter->GetType() == pTS->CreatePointerTypeTo(StackElement_Type)) {
-		pElementVariableValuePter = nullptr;
+	ForthType topElementType = this->pStack->GetTOSType();
+
+	if (topElementType == pTS->CreatePointerTypeTo(StackElement_Type)) {
 		if (this->ExecuteWordDirectly("@")) {
-			StackElement* pElementVariableValue;
-			pElementVariableValue = pStack->Pull();
-			if (pElementVariableValue == nullptr) {
-				return CreateStackOverflowException("whilst getting variable");
+			if (this->pStack->Count() == 0) {
+				return CreateStackOverflowException("whilst getting type variable");
 			}
-			variableValue = pElementVariableValue->GetValueType();
-			delete pElementVariableValue;
-			pElementVariableValue = nullptr;
+			ForthType tosType = this->pStack->GetTOSType();
+			if (tosType != StackElement_Type) {
+				return CreateException("Variable does not evaluate to an type");
+			}
+			variableValue = pStack->PullAsType();
 			return true;
 		}
 	}
@@ -438,68 +436,63 @@ bool ExecState::GetConstant(const std::string& constantName, int64_t& constantVa
 	if (!PushConstantOntoStack(constantName)) {
 		return false;
 	}
-	StackElement* pElementConstantValue = this->pStack->Pull();
-	bool success = false;
-	if (pElementConstantValue->GetType() == StackElement_Int)
-	{
-		constantValue = pElementConstantValue->GetInt();
-		success = true;
-	}
-	delete pElementConstantValue;
-	pElementConstantValue = nullptr;
 
-	return success;
+	if (this->pStack->Count() == 0) {
+		return CreateStackOverflowException("whilst getting int constant");
+	}
+	ForthType tosType = this->pStack->GetTOSType();
+	if (tosType != StackElement_Int && tosType != StackElement_Float && tosType != StackElement_Bool) {
+		return CreateException("Constant does not evaluate to an integer");
+	}
+	constantValue = this->pStack->PullAsInt();
+
+	return true;
 }
 
 bool ExecState::GetConstant(const std::string& constantName, double& constantValue) {
 	if (!PushConstantOntoStack(constantName)) {
 		return false;
 	}
-	StackElement* pElementConstantValue = this->pStack->Pull();
-	bool success = false;
-	if (pElementConstantValue->GetType() == StackElement_Float)
-	{
-		constantValue = pElementConstantValue->GetFloat();
-		success = true;
+	if (this->pStack->Count() == 0) {
+		return CreateStackOverflowException("whilst getting float constant");
 	}
-	delete pElementConstantValue;
-	pElementConstantValue = nullptr;
-
-	return success;
+	ForthType tosType = this->pStack->GetTOSType();
+	if (tosType != StackElement_Int && tosType != StackElement_Float && tosType != StackElement_Bool) {
+		return CreateException("Constant does not evaluate to a float");
+	}
+	constantValue = this->pStack->PullAsFloat();
+	return true;
 }
 
 bool ExecState::GetConstant(const std::string& constantName, bool& constantValue) {
 	if (!PushConstantOntoStack(constantName)) {
 		return false;
 	}
-	StackElement* pElementConstantValue = this->pStack->Pull();
-	bool success = false;
-	if (pElementConstantValue->GetType() == StackElement_Bool)
-	{
-		constantValue = pElementConstantValue->GetBool();
-		success = true;
+	if (this->pStack->Count() == 0) {
+		return CreateStackOverflowException("whilst getting bool constant");
 	}
-	delete pElementConstantValue;
-	pElementConstantValue = nullptr;
-
-	return success;
+	ForthType tosType = this->pStack->GetTOSType();
+	if (tosType != StackElement_Bool) {
+		return CreateException("Constant does not evaluate to a bool ");
+	}
+	constantValue = this->pStack->PullAsBool();
+	return true;
 }
 
 bool ExecState::GetConstant(const std::string& constantName, ForthType& constantValue) {
 	if (!PushConstantOntoStack(constantName)) {
 		return false;
 	}
-	StackElement* pElementConstantValue = this->pStack->Pull();
-	bool success = false;
-	if (pElementConstantValue->GetType() == StackElement_Type)
-	{
-		constantValue = pElementConstantValue->GetValueType();
-		success = true;
-	}
-	delete pElementConstantValue;
-	pElementConstantValue = nullptr;
 
-	return success;
+	if (this->pStack->Count() == 0) {
+		return CreateStackOverflowException("whilst getting type constant");
+	}
+	ForthType tosType = this->pStack->GetTOSType();
+	if (tosType != StackElement_Type) {
+		return CreateException("Constant does not evaluate to a type");
+	}
+	constantValue = this->pStack->PullAsType();
+	return true;
 }
 
 bool ExecState::GetConstant(const std::string& constantName, RefCountedObject*& constantValue) {
@@ -507,19 +500,16 @@ bool ExecState::GetConstant(const std::string& constantName, RefCountedObject*& 
 	if (!PushConstantOntoStack(constantName)) {
 		return false;
 	}
-	StackElement* pElementConstantValue = this->pStack->Pull();
-	bool success = false;
-
-	ForthType t = pElementConstantValue->GetType();
-	if (pTS->TypeIsObject(t)) {
-		constantValue = pElementConstantValue->GetObject();
-		constantValue->IncReference();
-		success = true;
+	if (this->pStack->Count() == 0) {
+		return CreateStackOverflowException("whilst getting object constant");
 	}
-	delete pElementConstantValue;
-	pElementConstantValue = nullptr;
-
-	return success;
+	ForthType tosType = this->pStack->GetTOSType();
+	if (!pTS->TypeIsObject(tosType)) {
+		return CreateException("Constant does not evaluate to an object");
+	}
+	constantValue = this->pStack->PullAsObject();
+	constantValue->IncReference();
+	return true;
 }
 
 
@@ -541,11 +531,15 @@ bool ExecState::ExecuteWordDirectly(const std::string& word) {
 	XT executeXT = ppExecBody[0]->wordElement_XT;
 
 	if (executeOnTOSObject) {
-		StackElement* pElementObjectToExecOn = this->pStack->Pull();
-		RefCountedObject* pObjToExecOn = pElementObjectToExecOn->GetObject();
+		if (this->pStack->Count() == 0) {
+			return CreateStackUnderflowException("Whilst executing a word directly");
+		}
+		ForthType tosType = this->pStack->GetTOSType();
+		if (!pTS->TypeIsObject(tosType)) {
+			return CreateException("Cannot execute a word on an object, where TOS is not an object");
+		}
+		RefCountedObject* pObjToExecOn = this->pStack->PullAsObject();
 		this->NestSelfPointer(pObjToExecOn);
-		delete pElementObjectToExecOn;
-		pElementObjectToExecOn = nullptr;
 	}
 
 	NestAndSetCFA(ppExecBody, 1);
@@ -582,12 +576,10 @@ bool ExecState::NestSelfPointer(RefCountedObject* pSelf) {
 }
 
 bool ExecState::UnnestSelfPointer() {
-	StackElement* pElement = this->pSelfStack->Pull();
-	if (pElement == nullptr) {
+	if (this->pSelfStack->Count() == 0) {
 		return CreateSelfStackUnderflowException();
 	}
-	delete pElement;
-	pElement = nullptr;
+	this->pSelfStack->DropTOS();
 	return true;
 }
 

--- a/SmallForth/ForthArray.h
+++ b/SmallForth/ForthArray.h
@@ -28,6 +28,6 @@ private:
 	bool SetElementAtIndex(ExecState* pExecState);
 private:
 	ForthType containedType;
-	std::vector<StackElement*> elements;
+	std::vector<StackElement> elements;
 };
 

--- a/SmallForth/ForthDefs.h
+++ b/SmallForth/ForthDefs.h
@@ -10,6 +10,7 @@ class RefCountedObject;
 typedef bool (*XT)(ExecState* pExecState);
 
 enum ElementType {
+	StackElement_Undefined = 0,
 	StackElement_Char = 1,
 	StackElement_Int,
 	StackElement_Float,

--- a/SmallForth/ForthString.cpp
+++ b/SmallForth/ForthString.cpp
@@ -249,35 +249,34 @@ bool ForthString::SubString(ExecState* pExecState) {
 
 // ( element object -- )
 bool ForthString::Append(ExecState* pExecState) {
-	StackElement* pElementToAppend = pExecState->pStack->Pull();
-	if (pElementToAppend == nullptr) {
-		return pExecState->CreateStackUnderflowException("cannot get char or codepoint element to appen to string");
+	if (pExecState->pStack->Count() ==0 ) {
+		return pExecState->CreateStackUnderflowException("cannot get char or codepoint element to append to string");
 	}
+	ForthType appendType = pExecState->pStack->GetTOSType();
+
 	char toAppend;
 	ForthString* pAppendString;
-	switch(pElementToAppend->GetType()) {
+
+	switch (appendType) {
 	case ObjectType_String:
-		pAppendString = (ForthString*)pElementToAppend->GetObject();
+		pAppendString = (ForthString*)pExecState->pStack->PullAsObject();
 		this->containedString += pAppendString->containedString;
 		break;
 	case StackElement_Char:
-		toAppend = pElementToAppend->GetChar();
+		toAppend = pExecState->pStack->PullAsChar();
 		this->containedString += toAppend;
 		break;
 	case ObjectType_ReadWriteFile:
 	case ObjectType_WriteFile:
+	{
+		StackElement* pElementToAppend = pExecState->pStack->Pull();
+
 		return AppendToFile(pExecState, pElementToAppend);
+	}
 	default:
-		delete pElementToAppend;
-		pElementToAppend = nullptr;
 		return pExecState->CreateException("Can only directly append characters and strings, to strings");
 	}
-
-	delete pElementToAppend;
-	pElementToAppend = nullptr;
-
-	StackElement* pElementNewString = new StackElement((RefCountedObject*)this);
-	if (!pExecState->pStack->Push(pElementNewString)) {
+	if (!pExecState->pStack->Push((RefCountedObject*)this)) {
 		return pExecState->CreateStackOverflowException();
 	}
 	return true;

--- a/SmallForth/ForthWord.h
+++ b/SmallForth/ForthWord.h
@@ -48,8 +48,6 @@ public:
 	static void BuiltInHelper_DeleteStackElement(StackElement*& pElement);
 	static bool BuiltInHelper_GetOneTempStackElement(ExecState* pExecState, StackElement*& pElement1);
 	static bool BuiltInHelper_GetOneStackElement(ExecState* pExecState, StackElement*& pElement1);
-	static bool BuiltInHelper_GetTwoStackElements(ExecState* pExecState, StackElement*& pElement1, StackElement*& pElement2);
-	static bool BuiltInHelper_GetThreeStackElements(ExecState* pExecState, StackElement*& pElement1, StackElement*& pElement2, StackElement*& pElement3);
 	static bool BuiltInHelper_UpdateForwardJump(ExecState* pExecState);
 	static bool BuiltInHelper_FetchLiteralWithOffset(ExecState* pExecState, int offset);
 	static bool BuiltInHelper_CompileTOSLiteral(ExecState* pExecState, bool includePushWord);

--- a/SmallForth/ForthWord.h
+++ b/SmallForth/ForthWord.h
@@ -43,7 +43,7 @@ public:
 	static bool BuiltIn_DescribeWord(ExecState* pExecState);
 
 	static bool BuiltInHelper_BinaryOperation(ExecState* pExecState, BinaryOperationType opType);
-	static bool BuiltInHelper_ObjectBinaryOperation(ExecState* pExecState, BinaryOperationType opType, StackElement* pElement1, StackElement* pElement2);
+	static bool BuiltInHelper_ObjectBinaryOperation(ExecState* pExecState, BinaryOperationType opType, const StackElement& element1, const StackElement& element2);
 	static void BuiltInHelper_DeleteOperands(StackElement*& pElement1, StackElement*& pElement2);
 	static void BuiltInHelper_DeleteStackElement(StackElement*& pElement);
 	static bool BuiltInHelper_GetOneTempStackElement(ExecState* pExecState, StackElement*& pElement1);

--- a/SmallForth/ForthWordBuiltInHelpers.cpp
+++ b/SmallForth/ForthWordBuiltInHelpers.cpp
@@ -198,32 +198,6 @@ bool ForthWord::BuiltInHelper_GetOneStackElement(ExecState* pExecState, StackEle
 	return true;
 }
 
-bool ForthWord::BuiltInHelper_GetTwoStackElements(ExecState* pExecState, StackElement*& pElement1, StackElement*& pElement2) {
-	pElement2 = pExecState->pStack->Pull();
-	pElement1 = pExecState->pStack->Pull();
-
-	if (pElement1 == nullptr || pElement2 == nullptr) {
-		delete pElement1;
-		delete pElement2;
-		return pExecState->CreateStackUnderflowException();
-	}
-	return true;
-}
-
-bool ForthWord::BuiltInHelper_GetThreeStackElements(ExecState* pExecState, StackElement*& pElement1, StackElement*& pElement2, StackElement*& pElement3) {
-	pElement3 = pExecState->pStack->Pull();
-	pElement2 = pExecState->pStack->Pull();
-	pElement1 = pExecState->pStack->Pull();
-
-	if (pElement1 == nullptr || pElement2 == nullptr || pElement3 == nullptr) {
-		delete pElement1;
-		delete pElement2;
-		delete pElement3;
-		return pExecState->CreateStackUnderflowException();
-	}
-	return true;
-}
-
 // Relies on return stack TOS have the index into the word being defines literal element
 //  (The actual pushlit that preceeds the actual value - it will have 1 added to it)
 bool ForthWord::BuiltInHelper_UpdateForwardJump(ExecState* pExecState) {

--- a/SmallForth/ForthWordBuiltInHelpers.cpp
+++ b/SmallForth/ForthWordBuiltInHelpers.cpp
@@ -27,6 +27,11 @@ bool ForthWord::BuiltInHelper_BinaryOperation(ExecState* pExecState, BinaryOpera
 	ForthType type1 = pElement1->GetType();
 	ForthType type2 = pElement2->GetType();
 
+	//type1 = pExecState->pStack->GetTOSType();
+	//pExecState->pStack->SwapTOS();
+	//type2 = pExecState->pStack->GetTOSType();
+	//pExecState->pStack->SwapTOS();
+
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
 	if (pTS->TypeIsObject(type1)) {
 		return BuiltInHelper_ObjectBinaryOperation(pExecState, opType, pElement1, pElement2);

--- a/SmallForth/ForthWordBuiltInHelpers.cpp
+++ b/SmallForth/ForthWordBuiltInHelpers.cpp
@@ -25,8 +25,8 @@ bool ForthWord::BuiltInHelper_BinaryOperation(ExecState* pExecState, BinaryOpera
 
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
 	if (pTS->TypeIsObject(type1)) {
-		StackElement element2 = pExecState->pStack->PullAsRef();
-		StackElement element1 = pExecState->pStack->PullAsRef();
+		StackElement element2 = pExecState->pStack->PullNoPter();
+		StackElement element1 = pExecState->pStack->PullNoPter();
 		return BuiltInHelper_ObjectBinaryOperation(pExecState, opType, element1, element2);
 	}
 	else if (type1 == StackElement_Float || type2 == StackElement_Float) {

--- a/SmallForth/ForthWordObjectHandling.cpp
+++ b/SmallForth/ForthWordObjectHandling.cpp
@@ -26,7 +26,7 @@ bool PreBuiltWords::BuiltIn_StringLiteral(ExecState* pExecState) {
 		if (firstPart) {
 			// literals start with "_ and that first space (represented by underscore) should not be added, so it is -1 here on the loop comparison
 			firstPart = false;
-			for (int i = 0; i < pExecState->delimitersAfterCurrentWord-1; ++i) {
+			for (int i = 0; i < pExecState->delimitersAfterCurrentWord - 1; ++i) {
 				literal += " ";
 			}
 		}
@@ -69,7 +69,7 @@ bool PreBuiltWords::BuiltIn_CallObject(ExecState* pExecState) {
 
 	ForthType addressType = pElementAddress->GetType();
 	ForthType indexType = pElementFunctionIndex->GetType();
-	if (!pTS->TypeIsObject(addressType) || indexType!=StackElement_Int) {
+	if (!pTS->TypeIsObject(addressType) || indexType != StackElement_Int) {
 		ForthWord::BuiltInHelper_DeleteOperands(pElementFunctionIndex, pElementAddress);
 		return pExecState->CreateException("Invoking call must have ( index objaddr -- )");
 	}
@@ -84,17 +84,13 @@ bool PreBuiltWords::BuiltIn_CallObject(ExecState* pExecState) {
 bool PreBuiltWords::BuiltIn_Construct(ExecState* pExecState) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
 
-	StackElement* pElementType;
-	bool incorrectType;
-	std::tie(incorrectType, pElementType) = pExecState->pStack->PullType(StackElement_Type);
-	if (incorrectType) {
-		return pExecState->CreateException("Must have a type to construct with");
-	} else if (pElementType == nullptr) {
-		return pExecState->CreateStackUnderflowException();
+	if (pExecState->pStack->Count() == 0) {
+		return pExecState->CreateStackUnderflowException("Whilst constructing object");
 	}
-
-	ForthType type = pElementType->GetValueType();
-	ForthWord::BuiltInHelper_DeleteStackElement(pElementType);
+	if (pExecState->pStack->GetTOSType() != StackElement_Type) {
+		return pExecState->CreateException("Must have a type to construct with");
+	}
+	ForthType type = pExecState->pStack->PullAsType();
 
 	if (pTS->GetIndirectionLevel(type) > 0) {
 		return pExecState->CreateException("Currently constructing pointers to objects is not supported");
@@ -106,21 +102,24 @@ bool PreBuiltWords::BuiltIn_Construct(ExecState* pExecState) {
 bool PreBuiltWords::BuiltIn_DefineObject(ExecState* pExecState) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
 
-	StackElement* pElementObjectName;
-	StackElement* pElementStateCount;
-	if (!ForthWord::BuiltInHelper_GetTwoStackElements(pExecState, pElementStateCount, pElementObjectName)) {
-		return false;
+	if (pExecState->pStack->Count() < 2) {
+		return pExecState->CreateStackUnderflowException("whilst defining an object - need ( n $ -- )");
 	}
-	if (pElementObjectName->GetType() != ObjectType_String ||
-		pElementStateCount->GetType() != StackElement_Int) {
-		ForthWord::BuiltInHelper_DeleteOperands(pElementStateCount, pElementObjectName);
-		return pExecState->CreateException("Define objects must be called with ( [state] n $ -- ");
-	}
-	ForthString* pString = (ForthString* )pElementObjectName->GetObject();
-	std::string newTypeName = pString->GetContainedString();
-	int stateCount = (int)pElementStateCount->GetInt();
 
-	ForthWord::BuiltInHelper_DeleteOperands(pElementStateCount, pElementObjectName);
+	if (!pExecState->pStack->TOSIsType((ElementType)ObjectType_String)) {
+		return pExecState->CreateException("Need an object name when defining an object");
+	}
+
+	bool successGettingString;
+	std::string newTypeName;
+	std::tie(successGettingString, newTypeName) = pExecState->pStack->PullAsString();
+	if (!successGettingString) {
+		return pExecState->CreateException(newTypeName.c_str());
+	}
+	if (!pExecState->pStack->TOSIsType(StackElement_Int)) {
+		return pExecState->CreateException("Need an element count when defining an object");
+	}
+	int stateCount = (int)pExecState->pStack->PullAsInt();
 
 	if (pTS->TypeExists(newTypeName)) {
 		return pExecState->CreateException("Object type already exists");

--- a/SmallForth/InputProcessor.cpp
+++ b/SmallForth/InputProcessor.cpp
@@ -203,8 +203,10 @@ bool InputProcessor::Interpret(ExecState* pExecState) {
 		catch (...) {
 			HandleException(pExecState, nullptr, "Non std exception: ");
 		}
-		pExecState->pWordBeingInterpreted->DecReference();
-		pExecState->pWordBeingInterpreted = nullptr;
+		if (pExecState->pWordBeingInterpreted != nullptr) {
+			pExecState->pWordBeingInterpreted->DecReference();
+			pExecState->pWordBeingInterpreted = nullptr;
+		}
 	}
 
 	delete pExecState;

--- a/SmallForth/PreBuiltWords.cpp
+++ b/SmallForth/PreBuiltWords.cpp
@@ -1827,63 +1827,61 @@ bool PreBuiltWords::BuiltIn_Not(ExecState* pExecState) {
 }
 
 bool PreBuiltWords::BuiltIn_Or(ExecState* pExecState) {
-	StackElement* pElement1;
-	StackElement* pElement2;
-	if (!ForthWord::BuiltInHelper_GetTwoStackElements(pExecState, pElement1, pElement2)) {
-		return false;
+	if (pExecState->pStack->Count() < 2) {
+		return pExecState->CreateStackUnderflowException("whlst executing OR");
 	}
-	if (pElement1->GetType() != StackElement_Bool ||
-		pElement2->GetType() != StackElement_Bool) {
-		ForthWord::BuiltInHelper_DeleteOperands(pElement1, pElement2);
-		return pExecState->CreateException("OR operation needs two booleans");
+	ForthType t1 = pExecState->pStack->GetTOSType();
+	pExecState->pStack->SwapTOS();
+	ForthType t2 = pExecState->pStack->GetTOSType();
+	pExecState->pStack->SwapTOS();
+	if (t1 != StackElement_Bool ||
+		t2 != StackElement_Bool) {
+		return pExecState->CreateException("OR expects two bools ( b b -- b )");
 	}
-	bool value1 = pElement1->GetBool();
-	bool value2 = pElement2->GetBool();
-	ForthWord::BuiltInHelper_DeleteOperands(pElement1, pElement2);
+	bool value2 = pExecState->pStack->PullAsBool();
+	bool value1 = pExecState->pStack->PullAsBool();
 
 	if (!pExecState->pStack->Push(value1 || value2)) {
 		return pExecState->CreateStackUnderflowException();
 	}
-
 	return true;
 }
 
 bool PreBuiltWords::BuiltIn_And(ExecState* pExecState) {
-	StackElement* pElement1;
-	StackElement* pElement2;
-	if (!ForthWord::BuiltInHelper_GetTwoStackElements(pExecState, pElement1, pElement2)) {
-		return false;
+	if (pExecState->pStack->Count() < 2) {
+		return pExecState->CreateStackUnderflowException("whlst executing AND");
 	}
-	if (pElement1->GetType() != StackElement_Bool ||
-		pElement2->GetType() != StackElement_Bool) {
-		ForthWord::BuiltInHelper_DeleteOperands(pElement1, pElement2);
-		return pExecState->CreateException("AMD operation needs two booleans");
+	ForthType t1 = pExecState->pStack->GetTOSType();
+	pExecState->pStack->SwapTOS();
+	ForthType t2 = pExecState->pStack->GetTOSType();
+	pExecState->pStack->SwapTOS();
+	if (t1 != StackElement_Bool ||
+		t2 != StackElement_Bool) {
+		return pExecState->CreateException("AND expects two bools ( b b -- b )");
 	}
-	bool value1 = pElement1->GetBool();
-	bool value2 = pElement2->GetBool();
-	ForthWord::BuiltInHelper_DeleteOperands(pElement1, pElement2);
+	bool value2 = pExecState->pStack->PullAsBool();
+	bool value1 = pExecState->pStack->PullAsBool();
 
 	if (!pExecState->pStack->Push(value1 && value2)) {
 		return pExecState->CreateStackUnderflowException();
 	}
-
 	return true;
 }
 
 bool PreBuiltWords::BuiltIn_Xor(ExecState* pExecState) {
-	StackElement* pElement1;
-	StackElement* pElement2;
-	if (!ForthWord::BuiltInHelper_GetTwoStackElements(pExecState, pElement1, pElement2)) {
-		return false;
+	if (pExecState->pStack->Count() < 2) {
+		return pExecState->CreateStackUnderflowException("whlst executing XOR");
 	}
-	if (pElement1->GetType() != StackElement_Bool ||
-		pElement2->GetType() != StackElement_Bool) {
-		ForthWord::BuiltInHelper_DeleteOperands(pElement1, pElement2);
-		return pExecState->CreateException("XOR operation needs two booleans");
+	ForthType t1 = pExecState->pStack->GetTOSType();
+	pExecState->pStack->SwapTOS();
+	ForthType t2 = pExecState->pStack->GetTOSType();
+	pExecState->pStack->SwapTOS();
+	if (t1 != StackElement_Bool ||
+		t2 != StackElement_Bool) {
+		return pExecState->CreateException("XOR expects two bools ( b b -- b )");
 	}
-	bool value1 = pElement1->GetBool();
-	bool value2 = pElement2->GetBool();
-	ForthWord::BuiltInHelper_DeleteOperands(pElement1, pElement2);
+	bool value2 = pExecState->pStack->PullAsBool();
+	bool value1 = pExecState->pStack->PullAsBool();
 
 	if (!pExecState->pStack->Push(value1 != value2)) {
 		return pExecState->CreateStackUnderflowException();

--- a/SmallForth/PreBuiltWords.cpp
+++ b/SmallForth/PreBuiltWords.cpp
@@ -1892,22 +1892,19 @@ bool PreBuiltWords::BuiltIn_Xor(ExecState* pExecState) {
 
 bool PreBuiltWords::BuiltIn_Power(ExecState* pExecState) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
-	StackElement* pElement1;
-	StackElement* pElement2;
-	if (!ForthWord::BuiltInHelper_GetTwoStackElements(pExecState, pElement1, pElement2)) {
-		return false;
+
+	if (pExecState->pStack->Count() < 2) {
+		return pExecState->CreateStackUnderflowException("whlst executing XOR");
 	}
-	ForthType type1 = pElement1->GetType();
-	ForthType type2 = pElement2->GetType();
-	if (!pTS->IsNumeric(type1) || !pTS->IsNumeric(type2)) {
-		ForthWord::BuiltInHelper_DeleteOperands(pElement1, pElement2);
+	ForthType t1 = pExecState->pStack->GetTOSType();
+	pExecState->pStack->SwapTOS();
+	ForthType t2 = pExecState->pStack->GetTOSType();
+	pExecState->pStack->SwapTOS();
+	if (!pTS->IsNumeric(t1) || !pTS->IsNumeric(t2)) {
 		return pExecState->CreateException("Power function needs to numeric elements to operate on");
 	}
-	// Return x ^ y
-	double x = pElement1->GetFloat();
-	double y = pElement2->GetFloat();
-	ForthWord::BuiltInHelper_DeleteOperands(pElement1, pElement2);
-
+	double y = pExecState->pStack->PullAsFloat();
+	double x = pExecState->pStack->PullAsFloat();
 	double toReturn = pow(x, y);
 	if (!pExecState->pStack->Push(toReturn)) {
 		return pExecState->CreateStackOverflowException("whilst pushing result of power function");
@@ -1917,6 +1914,20 @@ bool PreBuiltWords::BuiltIn_Power(ExecState* pExecState) {
 
 bool PreBuiltWords::BuiltIn_Cos(ExecState* pExecState) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
+	if (pExecState->pStack->Count() < 1) {
+		return pExecState->CreateStackUnderflowException("whlst executing COS");
+	}
+	ForthType type = pExecState->pStack->GetTOSType();
+	if (!pTS->IsNumeric(type)) {
+		return pExecState->CreateException("Cos function needs a numeric to operate on");
+	}
+	double theta = pExecState->pStack->PullAsFloat();
+	double toReturn = cos(theta);
+	if (!pExecState->pStack->Push(toReturn)) {
+		return pExecState->CreateStackOverflowException("whilst pushing result of cosine function");
+	}
+	return true;
+
 	StackElement* pElement;
 	if (!ForthWord::BuiltInHelper_GetOneStackElement(pExecState, pElement)) {
 		return false;
@@ -1926,32 +1937,19 @@ bool PreBuiltWords::BuiltIn_Cos(ExecState* pExecState) {
 		pElement = nullptr;
 		return pExecState->CreateException("Cos function needs a numeric to operate on");
 	}
-
-	double theta = pElement->GetFloat();
-	delete pElement;
-	pElement = nullptr;
-	double toReturn = cos(theta);
-	if (!pExecState->pStack->Push(toReturn)) {
-		return pExecState->CreateStackOverflowException("whilst pushing result of cosine function");
-	}
 	return true;
 }
 
 bool PreBuiltWords::BuiltIn_Sin(ExecState* pExecState) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
-	StackElement* pElement;
-	if (!ForthWord::BuiltInHelper_GetOneStackElement(pExecState, pElement)) {
-		return false;
+	if (pExecState->pStack->Count() < 1) {
+		return pExecState->CreateStackUnderflowException("whlst executing SIN");
 	}
-	if (!pTS->IsNumeric(pElement->GetType())) {
-		delete pElement;
-		pElement = nullptr;
-		return pExecState->CreateException("Sin function needs a numeric to operate on");
+	ForthType type = pExecState->pStack->GetTOSType();
+	if (!pTS->IsNumeric(type)) {
+		return pExecState->CreateException("SIN function needs a numeric to operate on");
 	}
-
-	double theta = pElement->GetFloat();
-	delete pElement;
-	pElement = nullptr;
+	double theta = pExecState->pStack->PullAsFloat();
 	double toReturn = sin(theta);
 	if (!pExecState->pStack->Push(toReturn)) {
 		return pExecState->CreateStackOverflowException("whilst pushing result of sine function");
@@ -1961,18 +1959,14 @@ bool PreBuiltWords::BuiltIn_Sin(ExecState* pExecState) {
 
 bool PreBuiltWords::BuiltIn_Tan(ExecState* pExecState) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
-	StackElement* pElement;
-	if (!ForthWord::BuiltInHelper_GetOneStackElement(pExecState, pElement)) {
-		return false;
+	if (pExecState->pStack->Count() < 1) {
+		return pExecState->CreateStackUnderflowException("whlst executing TAN");
 	}
-	if (!pTS->IsNumeric(pElement->GetType())) {
-		delete pElement;
-		pElement = nullptr;
-		return pExecState->CreateException("Tan function needs a numeric to operate on");
+	ForthType type = pExecState->pStack->GetTOSType();
+	if (!pTS->IsNumeric(type)) {
+		return pExecState->CreateException("TAN function needs a numeric to operate on");
 	}
-	double theta = pElement->GetFloat();
-	delete pElement;
-	pElement = nullptr;
+	double theta = pExecState->pStack->PullAsFloat();
 	double toReturn = tan(theta);
 	if (!pExecState->pStack->Push(toReturn)) {
 		return pExecState->CreateStackOverflowException("whilst pushing result of tan function");
@@ -1982,83 +1976,65 @@ bool PreBuiltWords::BuiltIn_Tan(ExecState* pExecState) {
 
 bool PreBuiltWords::BuiltIn_Arccosine(ExecState* pExecState) { 
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
-	StackElement* pElement;
-	if (!ForthWord::BuiltInHelper_GetOneStackElement(pExecState, pElement)) {
-		return false;
+	if (pExecState->pStack->Count() < 1) {
+		return pExecState->CreateStackUnderflowException("whlst executing ARCCOS");
 	}
-	if (!pTS->IsNumeric(pElement->GetType())) {
-		delete pElement;
-		pElement = nullptr;
-		return pExecState->CreateException("Cos-1 function needs a numeric to operate on");
+	ForthType type = pExecState->pStack->GetTOSType();
+	if (!pTS->IsNumeric(type)) {
+		return pExecState->CreateException("ARCOS function needs a numeric to operate on");
 	}
-
-	double theta = pElement->GetFloat();
-	delete pElement;
-	pElement = nullptr;
+	double theta = pExecState->pStack->PullAsFloat();
 	double toReturn = acos(theta);
 	if (!pExecState->pStack->Push(toReturn)) {
-		return pExecState->CreateStackOverflowException("whilst pushing result of arccosine function");
+		return pExecState->CreateStackOverflowException("whilst pushing result of arccos function");
 	}
 	return true;
 }
 
 bool PreBuiltWords::BuiltIn_Arcsine(ExecState* pExecState) { 
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
-	StackElement* pElement;
-	if (!ForthWord::BuiltInHelper_GetOneStackElement(pExecState, pElement)) {
-		return false;
+	if (pExecState->pStack->Count() < 1) {
+		return pExecState->CreateStackUnderflowException("whlst executing ARCSINE");
 	}
-	if (!pTS->IsNumeric(pElement->GetType())) {
-		delete pElement;
-		pElement = nullptr;
-		return pExecState->CreateException("Sin-1 function needs a numeric to operate on");
+	ForthType type = pExecState->pStack->GetTOSType();
+	if (!pTS->IsNumeric(type)) {
+		return pExecState->CreateException("ARCSINE function needs a numeric to operate on");
 	}
-
-	double theta = pElement->GetFloat();
-	delete pElement;
-	pElement = nullptr;
+	double theta = pExecState->pStack->PullAsFloat();
 	double toReturn = asin(theta);
 	if (!pExecState->pStack->Push(toReturn)) {
-		return pExecState->CreateStackOverflowException("whilst pushing result of a4rcsine function");
+		return pExecState->CreateStackOverflowException("whilst pushing result of arcsine function");
 	}
 	return true;
 }
 
 bool PreBuiltWords::BuiltIn_Arctan(ExecState* pExecState) { 
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
-	StackElement* pElement;
-	if (!ForthWord::BuiltInHelper_GetOneStackElement(pExecState, pElement)) {
-		return false;
+	if (pExecState->pStack->Count() < 1) {
+		return pExecState->CreateStackUnderflowException("whlst executing ARCTAN");
 	}
-	if (!pTS->IsNumeric(pElement->GetType())) {
-		delete pElement;
-		pElement = nullptr;
-		return pExecState->CreateException("Tan-1 function needs a numeric to operate on");
+	ForthType type = pExecState->pStack->GetTOSType();
+	if (!pTS->IsNumeric(type)) {
+		return pExecState->CreateException("ATAN function needs a numeric to operate on");
 	}
-	double theta = pElement->GetFloat();
-	delete pElement;
-	pElement = nullptr;
+	double theta = pExecState->pStack->PullAsFloat();
 	double toReturn = atan(theta);
 	if (!pExecState->pStack->Push(toReturn)) {
-		return pExecState->CreateStackOverflowException("whilst pushing result of arctan function");
+		return pExecState->CreateStackOverflowException("whilst pushing result of atan function");
 	}
 	return true;
 }
 
 bool PreBuiltWords::BuiltIn_Sqrt(ExecState* pExecState) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
-	StackElement* pElement;
-	if (!ForthWord::BuiltInHelper_GetOneStackElement(pExecState, pElement)) {
-		return false;
+	if (pExecState->pStack->Count() < 1) {
+		return pExecState->CreateStackUnderflowException("whlst executing SQRT");
 	}
-	if (!pTS->IsNumeric(pElement->GetType())) {
-		delete pElement;
-		pElement = nullptr;
-		return pExecState->CreateException("Sqrt function needs a numeric to operate on");
+	ForthType type = pExecState->pStack->GetTOSType();
+	if (!pTS->IsNumeric(type)) {
+		return pExecState->CreateException("SQRT function needs a numeric to operate on");
 	}
-	double x = pElement->GetFloat();
-	delete pElement;
-	pElement = nullptr;
+	double x = pExecState->pStack->PullAsFloat();
 	double toReturn = sqrt(x);
 	if (!pExecState->pStack->Push(toReturn)) {
 		return pExecState->CreateStackOverflowException("whilst pushing result of sqrt function");

--- a/SmallForth/PreBuiltWords.cpp
+++ b/SmallForth/PreBuiltWords.cpp
@@ -1539,17 +1539,9 @@ bool PreBuiltWords::BuiltIn_Dup(ExecState* pExecState) {
 
 // ( n m -- m n )
 bool PreBuiltWords::BuiltIn_Swap(ExecState* pExecState) {
-	StackElement* pElement1 = nullptr;
-	StackElement* pElement2 = nullptr;
-	// Element1 is further in the stack than element2
-	// ( Element1 Element2 -- Element2 Element1)
-	if (!ForthWord::BuiltInHelper_GetTwoStackElements(pExecState, pElement1, pElement2)) {
-		return false;
+	if (!pExecState->pStack->SwapTOS()) {
+		return pExecState->CreateStackUnderflowException("when executing SWAP");
 	}
-
-	pExecState->pStack->Push(pElement2);
-	pExecState->pStack->Push(pElement1);
-
 	return true;
 }
 

--- a/SmallForth/PreBuiltWords.cpp
+++ b/SmallForth/PreBuiltWords.cpp
@@ -457,8 +457,7 @@ bool PreBuiltWords::BuiltIn_ThreadSafeBoolVariable(ExecState* pExecState) {
 
 	WordBodyElement** ppWBE = pExecState->GetPointerToBoolStateVariable(index);
 	ForthType pterType = pTS->CreatePointerTypeTo(StackElement_Bool);
-	StackElement* pElementVariable = new StackElement(pterType, ppWBE);
-	if (!pExecState->pStack->Push(pElementVariable)) {
+	if (!pExecState->pStack->Push(pterType, ppWBE)) {
 		return pExecState->CreateStackOverflowException("whilst pushing a state boolean variable");
 	}
 	return true;
@@ -481,8 +480,7 @@ bool PreBuiltWords::BuiltIn_ThreadSafeIntVariable(ExecState* pExecState) {
 
 	WordBodyElement** ppWBE = pExecState->GetPointerToIntStateVariable(index);
 	ForthType pterType = pTS->CreatePointerTypeTo(StackElement_Int);
-	StackElement* pElementVariable = new StackElement(pterType, ppWBE);
-	if (!pExecState->pStack->Push(pElementVariable)) {
+	if (!pExecState->pStack->Push(pterType, ppWBE)) {
 		return pExecState->CreateStackOverflowException("whilst pushing a state int variable");
 	}
 	return true;
@@ -493,8 +491,7 @@ bool PreBuiltWords::BuiltIn_CompileState(ExecState* pExecState) {
 
 	WordBodyElement** ppWBE = pExecState->GetPointerToIntStateVariable(ExecState::c_compileStateIndex);
 	ForthType pterType = pTS->CreatePointerTypeTo(StackElement_Int);
-	StackElement* pElementVariable = new StackElement(pterType, ppWBE);
-	if (!pExecState->pStack->Push(pElementVariable)) {
+	if (!pExecState->pStack->Push(pterType, ppWBE)) {
 		return pExecState->CreateStackOverflowException("whilst pushing a state int variable");
 	}
 	return true;
@@ -505,8 +502,7 @@ bool PreBuiltWords::BuiltIn_PostponeState(ExecState* pExecState) {
 
 	WordBodyElement** ppWBE = pExecState->GetPointerToBoolStateVariable(ExecState::c_postponedExecIndex);
 	ForthType pterType = pTS->CreatePointerTypeTo(StackElement_Bool);
-	StackElement* pElementVariable = new StackElement(pterType, ppWBE);
-	if (!pExecState->pStack->Push(pElementVariable)) {
+	if (!pExecState->pStack->Push(pterType, ppWBE)) {
 		return pExecState->CreateStackOverflowException("whilst pushing a state boolean variable");
 	}
 	return true;
@@ -517,8 +513,7 @@ bool PreBuiltWords::BuiltIn_InsideCommentState(ExecState* pExecState) {
 
 	WordBodyElement** ppWBE = pExecState->GetPointerToBoolStateVariable(ExecState::c_insideCommentIndex);
 	ForthType pterType = pTS->CreatePointerTypeTo(StackElement_Bool);
-	StackElement* pElementVariable = new StackElement(pterType, ppWBE);
-	if (!pExecState->pStack->Push(pElementVariable)) {
+	if (!pExecState->pStack->Push(pterType, ppWBE)) {
 		return pExecState->CreateStackOverflowException("whilst pushing a state boolean variable");
 	}
 	return true;
@@ -529,8 +524,7 @@ bool PreBuiltWords::BuiltIn_InsideCommentLineState(ExecState* pExecState) {
 
 	WordBodyElement** ppWBE = pExecState->GetPointerToBoolStateVariable(ExecState::c_insideCommentLineIndex);
 	ForthType pterType = pTS->CreatePointerTypeTo(StackElement_Bool);
-	StackElement* pElementVariable = new StackElement(pterType, ppWBE);
-	if (!pExecState->pStack->Push(pElementVariable)) {
+	if (!pExecState->pStack->Push(pterType, ppWBE)) {
 		return pExecState->CreateStackOverflowException("whilst pushing a state boolean variable");
 	}
 	return true;
@@ -541,8 +535,7 @@ bool PreBuiltWords::BuiltIn_DebugState(ExecState* pExecState) {
 
 	WordBodyElement** ppWBE = pExecState->GetPointerToIntStateVariable(ExecState::c_debugStateIndex);
 	ForthType pterType = pTS->CreatePointerTypeTo(StackElement_Int);
-	StackElement* pElementVariable = new StackElement(pterType, ppWBE);
-	if (!pExecState->pStack->Push(pElementVariable)) {
+	if (!pExecState->pStack->Push(pterType, ppWBE)) {
 		return pExecState->CreateStackOverflowException("whilst pushing a state int variable");
 	}
 	return true;
@@ -974,14 +967,13 @@ bool PreBuiltWords::BuiltIn_Jump(ExecState* pExecState) {
 		InputProcessor::ResetExecutionHaltFlag();
 		return pExecState->CreateException("Halted");
 	}
-	StackElement* pElement = pExecState->pStack->Pull();
-	if (pElement == nullptr) {
-		return pExecState->CreateStackUnderflowException();
+	if (pExecState->pStack->Count() == 0) {
+		return pExecState->CreateStackUnderflowException("whilst jumping");
 	}
-	int64_t newIp = pElement->GetInt();
-
-	delete pElement;
-	pElement = nullptr;
+	else if (!pExecState->pStack->TOSIsType(StackElement_Int)) {
+		return pExecState->CreateException("Require an integer to jump");
+	}
+	int64_t newIp = pExecState->pStack->PullAsInt();
 
 	if (newIp == 0) {
 		// Initial CFA is generally DOCOL. However, it is an XT not a pointer to a body, which is what IP expects
@@ -998,15 +990,21 @@ bool PreBuiltWords::BuiltIn_JumpOnTrue(ExecState* pExecState) {
 		return pExecState->CreateException("Halted");
 	}
 
-	StackElement* pAddrElement = nullptr;
-	StackElement* pBoolElement = nullptr;
-	if (!ForthWord::BuiltInHelper_GetTwoStackElements(pExecState, pAddrElement, pBoolElement)) {
-		return false;
+	if (pExecState->pStack->Count() == 0) {
+		return pExecState->CreateStackUnderflowException("whilst executing JUMPONTRUE");
 	}
-	int64_t newIp = pAddrElement->GetInt();
-	bool flag = pBoolElement->GetBool();
+	else if (!pExecState->pStack->TOSIsType(StackElement_Bool)) {
+		return pExecState->CreateException("Require ( n b -- ) to execute JUMPONTRUE, no bool at TOS");
+	}
+	bool flag = pExecState->pStack->PullAsBool();
 
-	ForthWord::BuiltInHelper_DeleteOperands(pAddrElement, pBoolElement);
+	if (pExecState->pStack->Count() == 0) {
+		return pExecState->CreateStackUnderflowException("whilst executing JUMPONTRUE");
+	}
+	else if (!pExecState->pStack->TOSIsType(StackElement_Int)) {
+		return pExecState->CreateException("Require ( n b -- ) to execute JUMPONTRUE, no integer available");
+	}
+	int64_t newIp = pExecState->pStack->PullAsInt();
 
 	if (newIp == 0) {
 		return pExecState->CreateException("Cannot jump to initialise CFA in level-2 word");
@@ -1024,15 +1022,21 @@ bool PreBuiltWords::BuiltIn_JumpOnFalse(ExecState* pExecState) {
 		return pExecState->CreateException("Halted");
 	}
 
-	StackElement* pAddrElement = nullptr;
-	StackElement* pBoolElement = nullptr;
-	if (!ForthWord::BuiltInHelper_GetTwoStackElements(pExecState, pAddrElement, pBoolElement)) {
-		return false;
+	if (pExecState->pStack->Count() == 0) {
+		return pExecState->CreateStackUnderflowException("whilst executing JUMPONFALSE");
 	}
-	int64_t newIp = pAddrElement->GetInt();
-	bool flag = pBoolElement->GetBool();
+	else if (!pExecState->pStack->TOSIsType(StackElement_Bool)) {
+		return pExecState->CreateException("Require ( n b -- ) to execute JUMPONFALSE, no bool at TOS");
+	}
+	bool flag = pExecState->pStack->PullAsBool();
 
-	ForthWord::BuiltInHelper_DeleteOperands(pAddrElement, pBoolElement);
+	if (pExecState->pStack->Count() == 0) {
+		return pExecState->CreateStackUnderflowException("whilst executing JUMPONFALSE");
+	}
+	else if (!pExecState->pStack->TOSIsType(StackElement_Int)) {
+		return pExecState->CreateException("Require ( n b -- ) to execute JUMPONFALSE, no integer available");
+	}
+	int64_t newIp = pExecState->pStack->PullAsInt();
 
 	if (newIp == 0) {
 		return pExecState->CreateException("Cannot jump to initialise CFA in level-2 word");
@@ -1098,8 +1102,7 @@ bool PreBuiltWords::BuiltIn_WordCFAFromInputStream(ExecState* pExecState) {
 		return pExecState->CreateException("Cannot find word in dictionary");
 	}
 	WordBodyElement** pCFA = pWord->GetPterToBody();
-	StackElement* pNewElement = new StackElement(pCFA);
-	pExecState->pStack->Push(pNewElement);
+	pExecState->pStack->Push(pCFA);
 	return true;
 }
 
@@ -1109,7 +1112,7 @@ bool PreBuiltWords::BuiltIn_WordCFAFromDefinition(ExecState* pExecState) {
 	if (pWBE == nullptr) {
 		return pExecState->CreateException("Expecting a word pointer in definition");
 	}
-	if (!pExecState->pStack->Push(new StackElement(pWBE->wordElement_BodyPter))) {
+	if (!pExecState->pStack->Push(pWBE->wordElement_BodyPter)) {
 		return pExecState->CreateStackUnderflowException();
 	}
 	return true;
@@ -1500,8 +1503,7 @@ bool PreBuiltWords::IsObject(ExecState* pExecState) {
 	ForthType t = pElement->GetType();
 	delete pElement;
 	pElement = nullptr;
-	StackElement* pReturnElement = new StackElement(pTS->TypeIsObject(t));
-	if (!pExecState->pStack->Push(pReturnElement)) {
+	if (!pExecState->pStack->Push(pTS->TypeIsObject(t))) {
 		return pExecState->CreateStackOverflowException("whilst determining if a type is an object");
 	}
 	return true;
@@ -1513,8 +1515,7 @@ bool PreBuiltWords::IsPter(ExecState* pExecState) {
 	ForthType t = pElement->GetType();
 	delete pElement;
 	pElement = nullptr;
-	StackElement* pReturnElement = new StackElement(TypeSystem::IsPter(t));
-	if (!pExecState->pStack->Push(pReturnElement)) {
+	if (!pExecState->pStack->Push(TypeSystem::IsPter(t))) {
 		return pExecState->CreateStackOverflowException("whilst determining if a type is a pter");
 	}
 	return true;
@@ -1667,9 +1668,8 @@ bool PreBuiltWords::BuiltIn_PushTempStackToDataStack(ExecState* pExecState) {
 
 bool PreBuiltWords::BuiltIn_StackSize(ExecState* pExecState) {
 	int64_t stackSize = pExecState->pStack->Count();
-	StackElement* pNewElement = new StackElement(stackSize);
 	// If push fails, it deletes the element
-	if (!pExecState->pStack->Push(pNewElement)) {
+	if (!pExecState->pStack->Push(stackSize)) {
 		return pExecState->CreateStackOverflowException();
 	}
 	return true;
@@ -1677,9 +1677,8 @@ bool PreBuiltWords::BuiltIn_StackSize(ExecState* pExecState) {
 
 bool PreBuiltWords::BuiltIn_RStackSize(ExecState* pExecState) {
 	int64_t stackSize = pExecState->pReturnStack->Count();
-	StackElement* pNewElement = new StackElement(stackSize);
 	// If push fails, it deletes the element
-	if (!pExecState->pStack->Push(pNewElement)) {
+	if (!pExecState->pStack->Push(stackSize)) {
 		return pExecState->CreateStackOverflowException();
 	}
 	return true;
@@ -1687,9 +1686,8 @@ bool PreBuiltWords::BuiltIn_RStackSize(ExecState* pExecState) {
 
 bool PreBuiltWords::BuiltIn_TStackSize(ExecState* pExecState) {
 	int64_t stackSize = pExecState->pTempStack->Count();
-	StackElement* pNewElement = new StackElement(stackSize);
 	// If push fails, it deletes the element
-	if (!pExecState->pStack->Push(pNewElement)) {
+	if (!pExecState->pStack->Push(stackSize)) {
 		return pExecState->CreateStackOverflowException();
 	}
 	return true;
@@ -1805,8 +1803,7 @@ bool PreBuiltWords::BuiltIn_Not(ExecState* pExecState) {
 	delete pElement;
 	pElement = nullptr;
 
-	pElement = new StackElement(!value);
-	if (!pExecState->pStack->Push(pElement)) {
+	if (!pExecState->pStack->Push(!value)) {
 		return pExecState->CreateStackOverflowException();
 	}
 	return true;
@@ -1827,8 +1824,7 @@ bool PreBuiltWords::BuiltIn_Or(ExecState* pExecState) {
 	bool value2 = pElement2->GetBool();
 	ForthWord::BuiltInHelper_DeleteOperands(pElement1, pElement2);
 
-	StackElement* pElementResult = new StackElement(value1 || value2);
-	if (!pExecState->pStack->Push(pElementResult)) {
+	if (!pExecState->pStack->Push(value1 || value2)) {
 		return pExecState->CreateStackUnderflowException();
 	}
 
@@ -1850,8 +1846,7 @@ bool PreBuiltWords::BuiltIn_And(ExecState* pExecState) {
 	bool value2 = pElement2->GetBool();
 	ForthWord::BuiltInHelper_DeleteOperands(pElement1, pElement2);
 
-	StackElement* pElementResult = new StackElement(value1 && value2);
-	if (!pExecState->pStack->Push(pElementResult)) {
+	if (!pExecState->pStack->Push(value1 && value2)) {
 		return pExecState->CreateStackUnderflowException();
 	}
 
@@ -1873,8 +1868,7 @@ bool PreBuiltWords::BuiltIn_Xor(ExecState* pExecState) {
 	bool value2 = pElement2->GetBool();
 	ForthWord::BuiltInHelper_DeleteOperands(pElement1, pElement2);
 
-	StackElement* pElementResult = new StackElement(value1 != value2);
-	if (!pExecState->pStack->Push(pElementResult)) {
+	if (!pExecState->pStack->Push(value1 != value2)) {
 		return pExecState->CreateStackUnderflowException();
 	}
 
@@ -2124,10 +2118,8 @@ bool PreBuiltWords::BuiltIn_PushPter(ExecState* pExecState) {
 	}
 	ForthType currentType = (*ppWBE_Type)->forthType;
 	ForthType pointerType = pTS->CreatePointerTypeTo(currentType);
-	//void* pter = reinterpret_cast<void*>(ppWBE_Literal[0]);
 	void* pter = static_cast<void*>(ppWBE_Literal);
-	StackElement* pNewStackElement = new StackElement(pointerType, pter);
-	if (!pExecState->pStack->Push(pNewStackElement)) {
+	if (!pExecState->pStack->Push(pointerType, pter)) {
 		return pExecState->CreateStackOverflowException();
 	}
 	return true;
@@ -2226,7 +2218,7 @@ bool PreBuiltWords::BuiltIn_PushUpcomingLiteral(ExecState* pExecState) {
 	}
 	ForthType forthType = (*ppWBE_Type)->forthType;
 
-	if (!pExecState->pStack->Push(new StackElement(forthType, ppWBE_Literal))) {
+	if (!pExecState->pStack->Push(forthType, ppWBE_Literal)) {
 		return pExecState->CreateStackOverflowException();
 	}
 	return true;

--- a/SmallForth/PreBuiltWords.cpp
+++ b/SmallForth/PreBuiltWords.cpp
@@ -182,7 +182,6 @@ void PreBuiltWords::RegisterWords(ForthDict* pDict) {
 
 	// Timer and time
 	InitialiseWord(pDict, "elapsedSeconds", PreBuiltWords::BuiltIn_GetHighResolutionTime);
-	InitialiseWord(pDict, "#sdc", PreBuiltWords::BuiltIn_StackDeletedCount);
 }
 
 void PreBuiltWords::CreateSecondLevelWords(ExecState* pExecState) {
@@ -1500,26 +1499,39 @@ bool PreBuiltWords::WordToFloat(ExecState* pExecState) {
 // ( [e] -- b ) true if [e] is object, false if [e] is pter to anything or value
 bool PreBuiltWords::IsObject(ExecState* pExecState) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
-	StackElement* pElement = pExecState->pStack->Pull();
+	StackElement element = pExecState->pStack->PullAsRef();
+	ForthType t = element.GetType();
+	if (!pExecState->pStack->Push(pTS->TypeIsObject(t))) {
+		return pExecState->CreateStackOverflowException("whilst determining if a type is an object");
+	}
+	return true;
+
+/*	StackElement* pElement = pExecState->pStack->Pull();
 	ForthType t = pElement->GetType();
 	delete pElement;
 	pElement = nullptr;
 	if (!pExecState->pStack->Push(pTS->TypeIsObject(t))) {
 		return pExecState->CreateStackOverflowException("whilst determining if a type is an object");
 	}
-	return true;
+	return true; */
 };
 
 // ( [e] -- b ) true if [e] is pter to object or value, false otherwise
 bool PreBuiltWords::IsPter(ExecState* pExecState) {
-	StackElement* pElement = pExecState->pStack->Pull();
-	ForthType t = pElement->GetType();
-	delete pElement;
-	pElement = nullptr;
+	StackElement element = pExecState->pStack->PullAsRef();
+	ForthType t = element.GetType();
 	if (!pExecState->pStack->Push(TypeSystem::IsPter(t))) {
 		return pExecState->CreateStackOverflowException("whilst determining if a type is a pter");
 	}
 	return true;
+	//StackElement* pElement = pExecState->pStack->Pull();
+	//ForthType t = pElement->GetType();
+	//delete pElement;
+	//pElement = nullptr;
+	//if (!pExecState->pStack->Push(TypeSystem::IsPter(t))) {
+	//	return pExecState->CreateStackOverflowException("whilst determining if a type is a pter");
+	//}
+	//return true;
 };
 
 // ( n -- n n )
@@ -1551,48 +1563,73 @@ bool PreBuiltWords::BuiltIn_Drop(ExecState* pExecState) {
 
 // ( n m -- n m n)
 bool PreBuiltWords::BuiltIn_Over(ExecState* pExecState) {
-	StackElement* pElement1 = nullptr;
-	StackElement* pElement2 = nullptr;
+	if (pExecState->pStack->Count() < 2) {
+		return pExecState->CreateStackUnderflowException("whilst executing OVER");
+	}
 	// Element1 is further in the stack than element2
 	// ( Element1 Element2 -- Element2 Element1)
-	if (!ForthWord::BuiltInHelper_GetTwoStackElements(pExecState, pElement1, pElement2)) {
-		return false;
+	StackElement element2 = pExecState->pStack->PullAsRef();
+	StackElement element1 = pExecState->pStack->PullAsRef();
+
+	pExecState->pStack->Push(element1);
+	pExecState->pStack->Push(element2);
+	if (!pExecState->pStack->Push(element1)) {
+		return pExecState->CreateStackOverflowException("whilst executing OVER");
 	}
-	pExecState->pStack->Push(pElement1);
-	pExecState->pStack->Push(pElement2);
-	StackElement* pElement3 = new StackElement(*pElement1);
-	pExecState->pStack->Push(pElement3);
+
 	return true;
 }
 
 // ( m n p -- n p m)
 bool PreBuiltWords::BuiltIn_Rot(ExecState* pExecState) {
-	StackElement* pElementm = nullptr;
-	StackElement* pElementn = nullptr;
-	StackElement* pElementp = nullptr;
-	if (!ForthWord::BuiltInHelper_GetThreeStackElements(pExecState, pElementm, pElementn, pElementp)) {
-		return false;
+	if (pExecState->pStack->Count() < 3) {
+		return pExecState->CreateStackUnderflowException("whilst executing ROT");
 	}
-
-	pExecState->pStack->Push(pElementn);
-	pExecState->pStack->Push(pElementp);
-	pExecState->pStack->Push(pElementm);
+	StackElement elementp = pExecState->pStack->PullAsRef();
+	StackElement elementn = pExecState->pStack->PullAsRef();
+	StackElement elementm = pExecState->pStack->PullAsRef();
+	pExecState->pStack->Push(elementn);
+	pExecState->pStack->Push(elementp);
+	pExecState->pStack->Push(elementm);
 	return true;
+
+	//StackElement* pElementm = nullptr;
+	//StackElement* pElementn = nullptr;
+	//StackElement* pElementp = nullptr;
+	//if (!ForthWord::BuiltInHelper_GetThreeStackElements(pExecState, pElementm, pElementn, pElementp)) {
+	//	return false;
+	//}
+
+	//pExecState->pStack->Push(pElementn);
+	//pExecState->pStack->Push(pElementp);
+	//pExecState->pStack->Push(pElementm);
+	//return true;
 }
 
 // ( m n p -- p m n)
 bool PreBuiltWords::BuiltIn_ReverseRot(ExecState* pExecState) {
-	StackElement* pElementm = nullptr;
-	StackElement* pElementn = nullptr;
-	StackElement* pElementp = nullptr;
-	if (!ForthWord::BuiltInHelper_GetThreeStackElements(pExecState, pElementm, pElementn, pElementp)) {
-		return false;
+	if (pExecState->pStack->Count() < 3) {
+		return pExecState->CreateStackUnderflowException("whilst executing -ROT");
 	}
-
-	pExecState->pStack->Push(pElementp);
-	pExecState->pStack->Push(pElementm);
-	pExecState->pStack->Push(pElementn);
+	StackElement elementp = pExecState->pStack->PullAsRef();
+	StackElement elementn = pExecState->pStack->PullAsRef();
+	StackElement elementm = pExecState->pStack->PullAsRef();
+	pExecState->pStack->Push(elementp);
+	pExecState->pStack->Push(elementm);
+	pExecState->pStack->Push(elementn);
 	return true;
+
+	//StackElement* pElementm = nullptr;
+	//StackElement* pElementn = nullptr;
+	//StackElement* pElementp = nullptr;
+	//if (!ForthWord::BuiltInHelper_GetThreeStackElements(pExecState, pElementm, pElementn, pElementp)) {
+	//	return false;
+	//}
+
+	//pExecState->pStack->Push(pElementp);
+	//pExecState->pStack->Push(pElementm);
+	//pExecState->pStack->Push(pElementn);
+	//return true;
 }
 
 // >R ( a -- R: a )
@@ -2232,15 +2269,6 @@ bool PreBuiltWords::BuiltIn_GetHighResolutionTime(ExecState* pExecState) {
 	double elapsedSeconds = (double)time / (double)freq;
 	if (!pExecState->pStack->Push(elapsedSeconds)) {
 		return pExecState->CreateStackOverflowException("whilst getting high resolution time");
-	}
-	return true;
-}
-
-bool PreBuiltWords::BuiltIn_StackDeletedCount(ExecState* pExecState) {
-	int n = pExecState->pStack->DeletedCount();
-
-	if (!pExecState->pStack->Push((int64_t)n)) {
-		return pExecState->CreateStackOverflowException("whilst getting stack deleted count");
 	}
 	return true;
 }

--- a/SmallForth/PreBuiltWords.cpp
+++ b/SmallForth/PreBuiltWords.cpp
@@ -2066,7 +2066,7 @@ bool PreBuiltWords::BuiltIn_Peek(ExecState* pExecState) {
 	if (!pElementAddress->IsPter()) {
 		return pExecState->CreateException("Cannot load pter value, as top of stack is not a pointer");
 	}
-	pExecState->pStack->Pull();
+	pElementAddress = pExecState->pStack->Pull();
 
 	bool returnValue = true;
 	StackElement* pValueElement = pElementAddress->GetDerefedPterValueAsStackElement();
@@ -2092,7 +2092,7 @@ bool PreBuiltWords::BuiltIn_Poke(ExecState* pExecState) {
 	if (!pAddressElement->IsPter()) {
 		return pExecState->CreateException("Cannot store into pter value, as top of stack is not a pointer");
 	}
-	pExecState->pStack->Pull();
+	pAddressElement = pExecState->pStack->Pull();
 	StackElement* pValueElement = pExecState->pStack->Pull();
 	if (pValueElement == nullptr) {
 		delete pAddressElement;

--- a/SmallForth/PreBuiltWords.cpp
+++ b/SmallForth/PreBuiltWords.cpp
@@ -2098,7 +2098,7 @@ bool PreBuiltWords::BuiltIn_Peek(ExecState* pExecState) {
 	if (!pElementAddress->IsPter()) {
 		return pExecState->CreateException("Cannot load pter value, as top of stack is not a pointer");
 	}
-	pExecState->pStack->Pull();
+	pElementAddress = pExecState->pStack->Pull();
 
 	bool returnValue = true;
 	StackElement* pValueElement = pElementAddress->GetDerefedPterValueAsStackElement();
@@ -2124,7 +2124,7 @@ bool PreBuiltWords::BuiltIn_Poke(ExecState* pExecState) {
 	if (!pAddressElement->IsPter()) {
 		return pExecState->CreateException("Cannot store into pter value, as top of stack is not a pointer");
 	}
-	pExecState->pStack->Pull();
+	pAddressElement = pExecState->pStack->Pull();
 	StackElement* pValueElement = pExecState->pStack->Pull();
 	if (pValueElement == nullptr) {
 		delete pAddressElement;

--- a/SmallForth/PreBuiltWords.cpp
+++ b/SmallForth/PreBuiltWords.cpp
@@ -182,6 +182,7 @@ void PreBuiltWords::RegisterWords(ForthDict* pDict) {
 
 	// Timer and time
 	InitialiseWord(pDict, "elapsedSeconds", PreBuiltWords::BuiltIn_GetHighResolutionTime);
+	InitialiseWord(pDict, "#sdc", PreBuiltWords::BuiltIn_StackDeletedCount);
 }
 
 void PreBuiltWords::CreateSecondLevelWords(ExecState* pExecState) {
@@ -1523,17 +1524,12 @@ bool PreBuiltWords::IsPter(ExecState* pExecState) {
 
 // ( n -- n n )
 bool PreBuiltWords::BuiltIn_Dup(ExecState* pExecState) {
-	StackElement* pElement = pExecState->pStack->Pull();
-
-	if (pElement == nullptr) {
-		return pExecState->CreateException("Stack underflow");
+	if (pExecState->pStack->Count() == 0) {
+		return pExecState->CreateStackUnderflowException("whilst executing DUP");
 	}
-
-	StackElement* pClonedElement = new StackElement(*pElement);
-
-	pExecState->pStack->Push(pElement);
-	pExecState->pStack->Push(pClonedElement);
-
+	if (!pExecState->pStack->DupTOS()) {
+		return pExecState->CreateStackOverflowException("whilst executing DUP");
+	}
 	return true;
 }
 
@@ -1547,12 +1543,9 @@ bool PreBuiltWords::BuiltIn_Swap(ExecState* pExecState) {
 
 // ( n -- )
 bool PreBuiltWords::BuiltIn_Drop(ExecState* pExecState) {
-	StackElement* pElement1 = nullptr;
-	if (!ForthWord::BuiltInHelper_GetOneStackElement(pExecState, pElement1)) {
-		return false;
+	if (!pExecState->pStack->DropTOS()) {
+		return pExecState->CreateStackUnderflowException("when executing DROP");
 	}
-	delete pElement1;
-	pElement1 = nullptr;
 	return true;
 }
 
@@ -1636,19 +1629,14 @@ bool PreBuiltWords::BuiltIn_ReverseRot(ExecState* pExecState) {
 
 // >R ( a -- R: a )
 bool PreBuiltWords::BuiltIn_PushDataStackToReturnStack(ExecState* pExecState) {
-	StackElement* pElement = nullptr;
-	if (!ForthWord::BuiltInHelper_GetOneStackElement(pExecState, pElement)) {
-		return false;
+	if (pExecState->pStack->Count() == 0) {
+		return pExecState->CreateStackUnderflowException("whilst executing >R");
 	}
-	if (pElement->GetType() != StackElement_Int) {
-		delete pElement;
-		pElement = nullptr;
+	else if (!pExecState->pStack->TOSIsType(StackElement_Int)) {
 		return pExecState->CreateException("Cannot push a non-integer to the return stack");
 	}
-	int nToPush = (int)pElement->GetInt();
-	delete pElement;
-	pElement = nullptr;
-	if (!pExecState->pReturnStack->Push(nToPush)) {
+	int64_t nToPush = pExecState->pStack->PullAsInt();
+	if (!pExecState->pReturnStack->Push((int)nToPush)) {
 		return pExecState->CreateReturnStackOverflowException();
 	}
 	return true;
@@ -2276,6 +2264,15 @@ bool PreBuiltWords::BuiltIn_GetHighResolutionTime(ExecState* pExecState) {
 	double elapsedSeconds = (double)time / (double)freq;
 	if (!pExecState->pStack->Push(elapsedSeconds)) {
 		return pExecState->CreateStackOverflowException("whilst getting high resolution time");
+	}
+	return true;
+}
+
+bool PreBuiltWords::BuiltIn_StackDeletedCount(ExecState* pExecState) {
+	int n = pExecState->pStack->DeletedCount();
+
+	if (!pExecState->pStack->Push((int64_t)n)) {
+		return pExecState->CreateStackOverflowException("whilst getting stack deleted count");
 	}
 	return true;
 }

--- a/SmallForth/PreBuiltWords.cpp
+++ b/SmallForth/PreBuiltWords.cpp
@@ -1499,7 +1499,7 @@ bool PreBuiltWords::WordToFloat(ExecState* pExecState) {
 // ( [e] -- b ) true if [e] is object, false if [e] is pter to anything or value
 bool PreBuiltWords::IsObject(ExecState* pExecState) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
-	StackElement element = pExecState->pStack->PullAsRef();
+	StackElement element = pExecState->pStack->PullNoPter();
 	ForthType t = element.GetType();
 	if (!pExecState->pStack->Push(pTS->TypeIsObject(t))) {
 		return pExecState->CreateStackOverflowException("whilst determining if a type is an object");
@@ -1518,7 +1518,7 @@ bool PreBuiltWords::IsObject(ExecState* pExecState) {
 
 // ( [e] -- b ) true if [e] is pter to object or value, false otherwise
 bool PreBuiltWords::IsPter(ExecState* pExecState) {
-	StackElement element = pExecState->pStack->PullAsRef();
+	StackElement element = pExecState->pStack->PullNoPter();
 	ForthType t = element.GetType();
 	if (!pExecState->pStack->Push(TypeSystem::IsPter(t))) {
 		return pExecState->CreateStackOverflowException("whilst determining if a type is a pter");
@@ -1568,8 +1568,8 @@ bool PreBuiltWords::BuiltIn_Over(ExecState* pExecState) {
 	}
 	// Element1 is further in the stack than element2
 	// ( Element1 Element2 -- Element2 Element1)
-	StackElement element2 = pExecState->pStack->PullAsRef();
-	StackElement element1 = pExecState->pStack->PullAsRef();
+	StackElement element2 = pExecState->pStack->PullNoPter();
+	StackElement element1 = pExecState->pStack->PullNoPter();
 
 	pExecState->pStack->Push(element1);
 	pExecState->pStack->Push(element2);
@@ -1585,9 +1585,9 @@ bool PreBuiltWords::BuiltIn_Rot(ExecState* pExecState) {
 	if (pExecState->pStack->Count() < 3) {
 		return pExecState->CreateStackUnderflowException("whilst executing ROT");
 	}
-	StackElement elementp = pExecState->pStack->PullAsRef();
-	StackElement elementn = pExecState->pStack->PullAsRef();
-	StackElement elementm = pExecState->pStack->PullAsRef();
+	StackElement elementp = pExecState->pStack->PullNoPter();
+	StackElement elementn = pExecState->pStack->PullNoPter();
+	StackElement elementm = pExecState->pStack->PullNoPter();
 	pExecState->pStack->Push(elementn);
 	pExecState->pStack->Push(elementp);
 	pExecState->pStack->Push(elementm);
@@ -1611,9 +1611,9 @@ bool PreBuiltWords::BuiltIn_ReverseRot(ExecState* pExecState) {
 	if (pExecState->pStack->Count() < 3) {
 		return pExecState->CreateStackUnderflowException("whilst executing -ROT");
 	}
-	StackElement elementp = pExecState->pStack->PullAsRef();
-	StackElement elementn = pExecState->pStack->PullAsRef();
-	StackElement elementm = pExecState->pStack->PullAsRef();
+	StackElement elementp = pExecState->pStack->PullNoPter();
+	StackElement elementn = pExecState->pStack->PullNoPter();
+	StackElement elementm = pExecState->pStack->PullNoPter();
 	pExecState->pStack->Push(elementp);
 	pExecState->pStack->Push(elementm);
 	pExecState->pStack->Push(elementn);

--- a/SmallForth/PreBuiltWords.h
+++ b/SmallForth/PreBuiltWords.h
@@ -182,6 +182,9 @@ public:
 	// Time, timers
 	static bool BuiltIn_GetHighResolutionTime(ExecState* pExecState);
 
+	// Temporary whilst optimising data stack
+	static bool BuiltIn_StackDeletedCount(ExecState* pExecState);
+
 private:
 	static bool BuiltIn_DoCol_Debug(ExecState* pExecState, std::ostream* pStdoutStream, int indentation);
 };

--- a/SmallForth/StackElement.cpp
+++ b/SmallForth/StackElement.cpp
@@ -93,12 +93,12 @@ StackElement& StackElement::operator=(const StackElement& element) {
 		if (pTS->TypeIsObject(elementType)) {
 			decObject = true;
 			objectToDec = this->valuePter;
-			typeToDec = element.elementType;
+			typeToDec = this->elementType;
 		}
 		else if (pTS->IsPter(elementType) && !pTS->IsValueOrValuePter(elementType)) {
 			decObjectPter = true;
 			objectToDec = this->valuePter;
-			typeToDec = element.elementType;
+			typeToDec = this->elementType;
 		}
 
 		elementType = element.elementType;
@@ -162,12 +162,12 @@ StackElement& StackElement::operator=(StackElement&& element) {
 		if (pTS->TypeIsObject(elementType)) {
 			decObject = true;
 			objectToDec = this->valuePter;
-			typeToDec = element.elementType;
+			typeToDec = this->elementType;
 		}
 		else if (pTS->IsPter(elementType) && !pTS->IsValueOrValuePter(elementType)) {
 			decObjectPter = true;
 			objectToDec = this->valuePter;
-			typeToDec = element.elementType;
+			typeToDec = this->elementType;
 		}
 
 
@@ -395,6 +395,9 @@ void StackElement::SetTo(ForthType forthType, void* value) {
 }
 
 void StackElement::RelinquishValue() {
+	if (elementType == StackElement_Undefined) {
+		return;
+	}
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
 	if (!pTS->IsValueOrValuePter(elementType)) {
 		pTS->DecReferenceForPter(elementType, this->valuePter);

--- a/SmallForth/StackElement.cpp
+++ b/SmallForth/StackElement.cpp
@@ -36,6 +36,7 @@ StackElement::StackElement(const StackElement& element) {
 			case StackElement_Float: this->valueDouble = element.valueDouble; break;
 			case StackElement_Type: this->valueType = element.valueType; break;
 			case StackElement_PterToCFA: this->valueWordBodyPter = element.valueWordBodyPter; break;
+			case StackElement_BinaryOpsType: this->valueBinaryOpsType = element.valueBinaryOpsType; break;
 			}
 		}
 	}
@@ -72,6 +73,7 @@ StackElement::StackElement(StackElement&& element) {
 			case StackElement_Float: this->valueDouble = element.valueDouble; element.valueDouble = 0.0; break;
 			case StackElement_Type: this->valueType = element.valueType; element.valueType = StackElement_Undefined; break;
 			case StackElement_PterToCFA: this->valueWordBodyPter = element.valueWordBodyPter; element.valueWordBodyPter = nullptr; break;
+			case StackElement_BinaryOpsType: this->valueBinaryOpsType = element.valueBinaryOpsType; element.valueBinaryOpsType = BinaryOp_Undefined; break;
 			}
 		}
 	}
@@ -119,6 +121,7 @@ StackElement& StackElement::operator=(const StackElement& element) {
 				case StackElement_Float: this->valueDouble = element.valueDouble; break;
 				case StackElement_Type: this->valueType = element.valueType; break;
 				case StackElement_PterToCFA: this->valueWordBodyPter = element.valueWordBodyPter; break;
+				case StackElement_BinaryOpsType: this->valueBinaryOpsType = element.valueBinaryOpsType; break;
 				}
 			}
 		}
@@ -187,6 +190,7 @@ StackElement& StackElement::operator=(StackElement&& element) {
 				case StackElement_Float: this->valueDouble = element.valueDouble; element.valueDouble = 0.0; break;
 				case StackElement_Type: this->valueType = element.valueType; element.valueType = StackElement_Undefined; break;
 				case StackElement_PterToCFA: this->valueWordBodyPter = element.valueWordBodyPter; element.valueWordBodyPter = nullptr; break;
+				case StackElement_BinaryOpsType: this->valueBinaryOpsType = element.valueBinaryOpsType; element.valueBinaryOpsType = BinaryOp_Undefined; break;
 				}
 			}
 		}

--- a/SmallForth/StackElement.cpp
+++ b/SmallForth/StackElement.cpp
@@ -57,7 +57,7 @@ StackElement::StackElement(StackElement&& element) {
 	TypeSystem* pTS = TypeSystem::GetTypeSystem();
 
 	elementType = element.elementType;
-	element.elementType == StackElement_Undefined;
+	element.elementType = StackElement_Undefined;
 	if (!pTS->IsPter(elementType)) {
 		if (pTS->TypeIsObject(elementType)) {
 			// See copy constructor for details why the object is copied like this, and not as part of the IsPter()=true clause
@@ -172,7 +172,7 @@ StackElement& StackElement::operator=(StackElement&& element) {
 
 
 		elementType = element.elementType;
-		element.elementType == StackElement_Undefined;
+		element.elementType = StackElement_Undefined;
 		if (!pTS->IsPter(elementType)) {
 			if (pTS->TypeIsObject(elementType)) {
 				// See copy constructor for details why the object is copied like this, and not as part of the IsPter()=true clause

--- a/SmallForth/StackElement.h
+++ b/SmallForth/StackElement.h
@@ -15,6 +15,10 @@ public:
 	StackElement(XT* pXt);
 	StackElement(BinaryOperationType opsType);
 	StackElement(const StackElement& element);
+	StackElement(StackElement&& element);
+	StackElement& operator=(const StackElement& element);
+	StackElement& operator=(StackElement&& element);
+
 //	StackElement(WordBodyElement*** pppWbe);
 	StackElement(ForthType v);
 	StackElement(RefCountedObject* pObject);

--- a/SmallForth/StackElement.h
+++ b/SmallForth/StackElement.h
@@ -6,6 +6,7 @@
 class StackElement
 {
 public:
+	StackElement();
 	StackElement(char c);
 	StackElement(int64_t n);
 	StackElement(double d);
@@ -20,6 +21,19 @@ public:
 	StackElement(ForthType forthType, WordBodyElement** ppLiteral);
 	StackElement(ForthType forthType, void* pter);
 	~StackElement();
+
+	void SetTo(char value);
+	void SetTo(int64_t value);
+	void SetTo(double value);
+	void SetTo(bool value);
+	void SetTo(WordBodyElement** value);
+	void SetTo(XT* value);
+	void SetTo(BinaryOperationType value);
+	void SetTo(ForthType value);
+	void SetTo(RefCountedObject* value);
+	void SetTo(ForthType forthType, WordBodyElement** value);
+	void SetTo(ForthType forthType, void* value);
+	void RelinquishValue();
 
 
 	ForthType GetType() const { return elementType; }


### PR DESCRIPTION
Refactoring Data stack to use StackElement and not StackElement*

Not all done, but a large part of the mostly used functionality has been refactored.  This is to prevent massive amounts of memory allocation/deallocation.